### PR TITLE
WIP fix(schema): rename button type attribute to avoid conflicts

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
+++ b/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
@@ -1399,7 +1399,7 @@ export interface Button {
   dataComponent?: DataComponentAttribute1;
   fillAnimation?: FillAnimation1;
   iconAnimation?: IconAnimation1;
-  type: TypeAttribute;
+  typeAttr: TypeAttribute;
   value?: ValueAttribute;
   name?: NameAttribute;
   disabled?: DisabledAttribute;

--- a/packages/components/base/source/1-atoms/button/button/ButtonProps.ts
+++ b/packages/components/base/source/1-atoms/button/button/ButtonProps.ts
@@ -81,7 +81,7 @@ export interface ButtonProps {
   dataComponent?: DataComponentAttribute;
   fillAnimation?: FillAnimation;
   iconAnimation?: IconAnimation;
-  type: TypeAttribute;
+  typeAttr: TypeAttribute;
   value?: ValueAttribute;
   name?: NameAttribute;
   disabled?: DisabledAttribute;

--- a/packages/components/base/source/1-atoms/button/button/button.schema.json
+++ b/packages/components/base/source/1-atoms/button/button/button.schema.json
@@ -84,7 +84,7 @@
     {
       "type": "object",
       "properties": {
-        "type": {
+        "typeAttr": {
           "type": "string",
           "enum": ["button", "submit", "reset"],
           "default": "button",
@@ -108,7 +108,7 @@
           "description": "Set the disabled attribute for the button"
         }
       },
-      "required": ["type"],
+      "required": ["typeAttr"],
       "additionalProperties": false
     }
   ]


### PR DESCRIPTION
Pretty sure this needs adjustment in the react component to keep working.

`type` was renamed because of collision in content schema. We already add a "virtual" `type` here to differentiate different content component interface instances, in a later step (e.g. GraphQL generation).