### PR TITLE
fix: escape media-queries in breakpoints token

### DIFF
--- a/packages/components/core/source/core/_breakpoint.scss
+++ b/packages/components/core/source/core/_breakpoint.scss
@@ -22,7 +22,7 @@ $breakpoints: (
   $breakpoints-json: ();
 
   @each $name, $value in $breakpoints {
-    $breakpoint: '"#{$name}":"#{$value}"';
+    $breakpoint: '\\"#{$name}\\":\\"#{$value}\\"';
     $breakpoints-json: append($breakpoints-json, $breakpoint, 'comma');
   }
 

--- a/packages/components/core/source/design-tokens/tokens.scss
+++ b/packages/components/core/source/design-tokens/tokens.scss
@@ -45,6 +45,6 @@
   --g-content-width-wide: 75rem;
 
   /* critical:start */
-  --breakpoints: #{breakpoint.breakpoints-to-json()};
+  --breakpoints: '#{breakpoint.breakpoints-to-json()}';
   /* critical:end */
 }

--- a/packages/components/core/source/utils/breakpoints.js
+++ b/packages/components/core/source/utils/breakpoints.js
@@ -4,6 +4,9 @@ import { domLoaded } from '../core/domLoaded';
 const breakpointEvents = {
   change: 'core.breakpoint.change',
 };
+const removeQuotes = (string) =>
+  // removes backslashes and leading & trailing doublequotes
+  string.replace(/\\|^\s*"|"\s*$/g, '');
 
 const includeMediaExport = (() => {
   let breakpoints = {};
@@ -16,7 +19,7 @@ const includeMediaExport = (() => {
       const raw = window
         .getComputedStyle(document.documentElement)
         .getPropertyValue('--breakpoints');
-      breakpoints = Object.entries(JSON.parse(raw)).reduce(
+      breakpoints = Object.entries(JSON.parse(removeQuotes(raw))).reduce(
         (prev, [breakpoint, value]) => {
           prev[breakpoint] = window.matchMedia(`(min-width:${value})`);
           prev[breakpoint].addEventListener(


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.0.1-canary.150.864.0
  npm install @kickstartds/blog@1.0.1-canary.150.864.0
  npm install @kickstartds/content@1.0.1-canary.150.864.0
  npm install @kickstartds/core@1.0.1-canary.150.864.0
  npm install @kickstartds/form@1.0.1-canary.150.864.0
  npm install @kickstartds/eslint-config@1.0.1-canary.150.864.0
  # or 
  yarn add @kickstartds/base@1.0.1-canary.150.864.0
  yarn add @kickstartds/blog@1.0.1-canary.150.864.0
  yarn add @kickstartds/content@1.0.1-canary.150.864.0
  yarn add @kickstartds/core@1.0.1-canary.150.864.0
  yarn add @kickstartds/form@1.0.1-canary.150.864.0
  yarn add @kickstartds/eslint-config@1.0.1-canary.150.864.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.0.1-next.4`
`@kickstartds/blog@1.0.1-next.4`
`@kickstartds/content@1.0.1-next.4`
`@kickstartds/core@1.0.1-next.3`
`@kickstartds/eslint-config@1.0.1-next.2`
`@kickstartds/form@1.0.1-next.4`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - chore: remove `netlify-cms` package [#147](https://github.com/kickstartDS/kickstartDS/pull/147) ([@lmestel](https://github.com/lmestel))
  - build: update storybook [#124](https://github.com/kickstartDS/kickstartDS/pull/124) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - fix: escape media-queries in breakpoints token [#150](https://github.com/kickstartDS/kickstartDS/pull/150) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/core`
    - Hotfix/ssr [#131](https://github.com/kickstartDS/kickstartDS/pull/131) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - fix(schema): minor schema updates [#129](https://github.com/kickstartDS/kickstartDS/pull/129) ([@julrich](https://github.com/julrich) [@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - Feature/auto [#119](https://github.com/kickstartDS/kickstartDS/pull/119) ([@lmestel](https://github.com/lmestel) [@julrich](https://github.com/julrich))
  
  #### ⚠️ Pushed to `next`
  
  - build: add packages to lerna.json ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build: remove unused dependencies [#148](https://github.com/kickstartDS/kickstartDS/pull/148) ([@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump husky from 6.0.0 to 7.0.0 [#144](https://github.com/kickstartDS/kickstartDS/pull/144) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup from 2.52.3 to 2.52.6 [#142](https://github.com/kickstartDS/kickstartDS/pull/142) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-schema-faker from 0.5.0-rcv.34 to 0.5.0-rcv.35 [#138](https://github.com/kickstartDS/kickstartDS/pull/138) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/cli from 6.3.1 to 6.3.2 [#132](https://github.com/kickstartDS/kickstartDS/pull/132) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump typescript from 4.3.4 to 4.3.5 [#130](https://github.com/kickstartDS/kickstartDS/pull/130) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump prettier from 2.3.1 to 2.3.2 [#122](https://github.com/kickstartDS/kickstartDS/pull/122) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump fast-glob from 3.2.5 to 3.2.6 [#123](https://github.com/kickstartDS/kickstartDS/pull/123) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - `@kickstartds/eslint-config`
    - build(deps): bump @typescript-eslint/parser from 4.28.0 to 4.28.1 [#140](https://github.com/kickstartDS/kickstartDS/pull/140) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump @typescript-eslint/eslint-plugin from 4.28.0 to 4.28.1 [#134](https://github.com/kickstartDS/kickstartDS/pull/134) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.11 to 17.0.13 [#143](https://github.com/kickstartDS/kickstartDS/pull/143) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - Build/revert dependency updates [#146](https://github.com/kickstartDS/kickstartDS/pull/146) ([@lmestel](https://github.com/lmestel))
    - build(deps): bump react-markdown from 5.0.3 to 6.0.2 [#145](https://github.com/kickstartDS/kickstartDS/pull/145) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump esbuild from 0.11.23 to 0.12.13 [#137](https://github.com/kickstartDS/kickstartDS/pull/137) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
