### PR TITLE
feat(documentation): trigger a release to fix versioning

### DIFF
--- a/packages/components/base/README.md
+++ b/packages/components/base/README.md
@@ -1,3 +1,3 @@
 # Base Module
 
-see `CHANGELOG.md` for version history
+see `CHANGELOG.md` for version history!

--- a/packages/components/blog/README.md
+++ b/packages/components/blog/README.md
@@ -1,3 +1,3 @@
 # Blog Module
 
-see `CHANGELOG.md` for version history
+see `CHANGELOG.md` for version history!

--- a/packages/components/content/README.md
+++ b/packages/components/content/README.md
@@ -1,3 +1,3 @@
 # Content Module
 
-see `CHANGELOG.md` for version history
+see `CHANGELOG.md` for version history!

--- a/packages/components/core/README.md
+++ b/packages/components/core/README.md
@@ -1,3 +1,3 @@
 # Core Module
 
-see `CHANGELOG.md` for version history
+see `CHANGELOG.md` for version history!

--- a/packages/components/form/README.md
+++ b/packages/components/form/README.md
@@ -1,3 +1,3 @@
 # Form Module
 
-see `CHANGELOG.md` for version history
+see `CHANGELOG.md` for version history!


### PR DESCRIPTION
As `1.0.1` was already used before, we need to jump to `1.1.0`, here!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.1.0-canary.166.1031.0
  npm install @kickstartds/blog@1.1.0-canary.166.1031.0
  npm install @kickstartds/content@1.1.0-canary.166.1031.0
  npm install @kickstartds/core@1.1.0-canary.166.1031.0
  npm install @kickstartds/form@1.1.0-canary.166.1031.0
  # or 
  yarn add @kickstartds/base@1.1.0-canary.166.1031.0
  yarn add @kickstartds/blog@1.1.0-canary.166.1031.0
  yarn add @kickstartds/content@1.1.0-canary.166.1031.0
  yarn add @kickstartds/core@1.1.0-canary.166.1031.0
  yarn add @kickstartds/form@1.1.0-canary.166.1031.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
