### PR TITLE
fix(storybook): set vite base path to '' for relative storybook assets

### DIFF
--- a/packages/tools/storybook/.storybook/main.js
+++ b/packages/tools/storybook/.storybook/main.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   async viteFinal(config, { configType }) {
     config.esbuild = { jsxInject: `import React from 'react'` };
+    config.base = '';
     return config;
   },
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.1.2-canary.211.1298.0
  npm install @kickstartds/blog@1.1.3-canary.211.1298.0
  npm install @kickstartds/content@1.1.2-canary.211.1298.0
  npm install @kickstartds/form@1.1.3-canary.211.1298.0
  # or 
  yarn add @kickstartds/base@1.1.2-canary.211.1298.0
  yarn add @kickstartds/blog@1.1.3-canary.211.1298.0
  yarn add @kickstartds/content@1.1.2-canary.211.1298.0
  yarn add @kickstartds/form@1.1.3-canary.211.1298.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
