### PR TITLE
fix: fix breakpoints parser

### DIFF
--- a/packages/components/core/source/utils/breakpoints.js
+++ b/packages/components/core/source/utils/breakpoints.js
@@ -5,8 +5,8 @@ const breakpointEvents = {
   change: 'core.breakpoint.change',
 };
 const removeQuotes = (string) =>
-  // removes backslashes and leading & trailing doublequotes
-  string.replace(/\\|^\s*"|"\s*$/g, '');
+  // removes backslashes and leading & trailing quotes
+  string.replace(/\\|^\s*['"]|['"]\s*$/g, '');
 
 const includeMediaExport = (() => {
   let breakpoints = {};


### PR DESCRIPTION
remove surrounding singlequotes from `--breakpoints` custom property (not only doublequotes)

#215
https://github.com/kickstartDS/gatsby-theme-kickstartDS/issues/22
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.1.2-canary.216.1308.0
  npm install @kickstartds/blog@1.1.3-canary.216.1308.0
  npm install @kickstartds/content@1.1.2-canary.216.1308.0
  npm install @kickstartds/core@1.1.2-canary.216.1308.0
  npm install @kickstartds/form@1.1.3-canary.216.1308.0
  # or 
  yarn add @kickstartds/base@1.1.2-canary.216.1308.0
  yarn add @kickstartds/blog@1.1.3-canary.216.1308.0
  yarn add @kickstartds/content@1.1.2-canary.216.1308.0
  yarn add @kickstartds/core@1.1.2-canary.216.1308.0
  yarn add @kickstartds/form@1.1.3-canary.216.1308.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
