### PR TITLE
chore: trigger release

### DIFF
--- a/packages/components/core/README.md
+++ b/packages/components/core/README.md
@@ -1,3 +1,3 @@
 # kickstartDS Core Module
 
-see `CHANGELOG.md` for version history!
+see `CHANGELOG.md` for version history


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.1.3-next.1`
`@kickstartds/blog@1.1.4-next.1`
`@kickstartds/content@1.1.3-next.1`
`@kickstartds/core@1.1.3-next.1`
`@kickstartds/form@1.1.4-next.1`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(storybook): set vite base path to '' for relative storybook assets [#211](https://github.com/kickstartDS/kickstartDS/pull/211) ([@julrich](https://github.com/julrich))
  - `@kickstartds/core`
    - chore: trigger release [#238](https://github.com/kickstartDS/kickstartDS/pull/238) ([@lmestel](https://github.com/lmestel))
    - fix: fix breakpoints parser [#216](https://github.com/kickstartDS/kickstartDS/pull/216) ([@lmestel](https://github.com/lmestel))
  
  #### ⚠️ Pushed to `next`
  
  - ci(commitlint): use different comparison for ignore ([@julrich](https://github.com/julrich))
  - ci(commitlint): add exception for lerna version update ([@julrich](https://github.com/julrich))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - Merge branch 'master' into next ([@lmestel](https://github.com/lmestel))
  
  #### 📝 Documentation
  
  - docs: remove storybook-addon-performance addon [#237](https://github.com/kickstartDS/kickstartDS/pull/237) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - storybook controls [#214](https://github.com/kickstartDS/kickstartDS/pull/214) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps-dev): bump lint-staged from 11.0.1 to 11.1.0 [#234](https://github.com/kickstartDS/kickstartDS/pull/234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.4 to 6.3.5 [#229](https://github.com/kickstartDS/kickstartDS/pull/229) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump auto from 10.29.3 to 10.30.0 [#226](https://github.com/kickstartDS/kickstartDS/pull/226) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup from 2.53.2 to 2.53.3 [#223](https://github.com/kickstartDS/kickstartDS/pull/223) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.5 to 8.3.6 [#222](https://github.com/kickstartDS/kickstartDS/pull/222) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.6 to 5.0.7 [#221](https://github.com/kickstartDS/kickstartDS/pull/221) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.4.2 to 2.4.3 [#217](https://github.com/kickstartDS/kickstartDS/pull/217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/core from 7.14.6 to 7.14.8 [#219](https://github.com/kickstartDS/kickstartDS/pull/219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.14.7 to 7.14.8 [#220](https://github.com/kickstartDS/kickstartDS/pull/220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump eslint from 7.30.0 to 7.31.0 [#212](https://github.com/kickstartDS/kickstartDS/pull/212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @rollup/plugin-replace from 2.4.2 to 3.0.0 [#213](https://github.com/kickstartDS/kickstartDS/pull/213) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.53.1 to 2.53.2 [#210](https://github.com/kickstartDS/kickstartDS/pull/210) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`
    - build(deps): bump date-fns from 2.22.1 to 2.23.0 [#235](https://github.com/kickstartDS/kickstartDS/pull/235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/runtime from 7.14.6 to 7.14.8 [#218](https://github.com/kickstartDS/kickstartDS/pull/218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
