### PR TITLE
add rgb color tokens

### DIFF
--- a/packages/components/core/source/design-tokens/colors/_colors.scss
+++ b/packages/components/core/source/design-tokens/colors/_colors.scss
@@ -5,11 +5,7 @@
 $brand--primary-r: 51 !default;
 $brand--primary-g: 51 !default;
 $brand--primary-b: 51 !default;
-$brand--primary: rgb(
-  var(--color-primary-r),
-  var(--color-primary-g),
-  var(--color-primary-b)
-) !default;
+$brand--primary: helpers.pack('primary') !default;
 $brand--primary-alpha: helpers.alpha('primary') !default;
 $brand--primary-lighter: helpers.mix('white', 'primary') !default;
 $brand--primary-darker: helpers.mix('black', 'primary') !default;
@@ -17,30 +13,18 @@ $brand--primary-darker: helpers.mix('black', 'primary') !default;
 $brand--secondary-r: 153 !default;
 $brand--secondary-g: 153 !default;
 $brand--secondary-b: 153 !default;
-$brand--secondary: rgb(
-  var(--color-secondary-r),
-  var(--color-secondary-g),
-  var(--color-secondary-b)
-) !default;
+$brand--secondary: helpers.pack('secondary') !default;
 
 $shades--white-r: 255 !default;
 $shades--white-g: 255 !default;
 $shades--white-b: 255 !default;
-$shades--white: rgb(
-  var(--color-white-r),
-  var(--color-white-g),
-  var(--color-white-b)
-) !default;
+$shades--white: helpers.pack('white') !default;
 $shades--white-alpha: helpers.alpha('white') !default;
 
 $shades--black-r: calc(var(--color-primary-r) * 0.1) !default;
 $shades--black-g: calc(var(--color-primary-g) * 0.1) !default;
 $shades--black-b: calc(var(--color-primary-b) * 0.1) !default;
-$shades--black: rgb(
-  var(--color-black-r),
-  var(--color-black-g),
-  var(--color-black-b)
-) !default;
+$shades--black: helpers.pack('black') !default;
 $shades--black-alpha: helpers.alpha('black') !default;
 
 $shades--grey: helpers.mix('black', 'white') !default;

--- a/packages/components/core/source/design-tokens/colors/_helpers.scss
+++ b/packages/components/core/source/design-tokens/colors/_helpers.scss
@@ -52,3 +52,11 @@ $factors: (1, 2, 3, 4, 5, 6, 7, 8, 9);
   }
   @return $color-map;
 }
+
+@function pack($name) {
+  @return rgb(
+    var(--color-#{$name}-r),
+    var(--color-#{$name}-g),
+    var(--color-#{$name}-b)
+  );
+}


### PR DESCRIPTION
This adds custom properties for every single RGB channel of `--color-primary`, `--color-secondary`, `--color-white` & `--color-black`, so shades are now calculated at runtime.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.1.3-next.9`
`@kickstartds/blog@1.1.4-next.8`
`@kickstartds/content@1.1.3-next.11`
`@kickstartds/core@1.1.3-next.6`
`@kickstartds/form@1.1.4-next.8`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - fix(storybook): set vite base path to '' for relative storybook assets [#211](https://github.com/kickstartDS/kickstartDS/pull/211) ([@julrich](https://github.com/julrich))
  - `@kickstartds/core`
    - add rgb color tokens [#269](https://github.com/kickstartDS/kickstartDS/pull/269) ([@lmestel](https://github.com/lmestel))
    - Revert "chore: trigger release" [#239](https://github.com/kickstartDS/kickstartDS/pull/239) ([@lmestel](https://github.com/lmestel))
    - chore: trigger release [#238](https://github.com/kickstartDS/kickstartDS/pull/238) ([@lmestel](https://github.com/lmestel))
    - fix: fix breakpoints parser [#216](https://github.com/kickstartDS/kickstartDS/pull/216) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - fix iframe alignment in TextMedia [#271](https://github.com/kickstartDS/kickstartDS/pull/271) ([@lmestel](https://github.com/lmestel))
    - Ci/component tokens [#259](https://github.com/kickstartDS/kickstartDS/pull/259) ([@lmestel](https://github.com/lmestel))
    - Ci/component tokens [#258](https://github.com/kickstartDS/kickstartDS/pull/258) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/content`
    - Hotfix/visual [#265](https://github.com/kickstartDS/kickstartDS/pull/265) ([@lmestel](https://github.com/lmestel))
    - fix visual content size with full size image [#260](https://github.com/kickstartDS/kickstartDS/pull/260) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`
    - fix: bring back visual slider nav [#257](https://github.com/kickstartDS/kickstartDS/pull/257) ([@lmestel](https://github.com/lmestel))
  
  #### ⚠️ Pushed to `next`
  
  - ci(commitlint): use different comparison for ignore ([@julrich](https://github.com/julrich))
  - ci(commitlint): add exception for lerna version update ([@julrich](https://github.com/julrich))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - Merge branch 'master' into next ([@lmestel](https://github.com/lmestel))
  
  #### 🏠 Internal
  
  - update vscode extension recommendations [#266](https://github.com/kickstartDS/kickstartDS/pull/266) ([@lmestel](https://github.com/lmestel))
  
  #### 📝 Documentation
  
  - docs: remove storybook-addon-performance addon [#237](https://github.com/kickstartDS/kickstartDS/pull/237) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - storybook controls [#214](https://github.com/kickstartDS/kickstartDS/pull/214) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps-dev): bump eslint from 7.31.0 to 7.32.0 [#275](https://github.com/kickstartDS/kickstartDS/pull/275) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.14.8 to 7.14.9 [#273](https://github.com/kickstartDS/kickstartDS/pull/273) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.55.0 to 2.55.1 [#267](https://github.com/kickstartDS/kickstartDS/pull/267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.54.0 to 2.55.0 [#264](https://github.com/kickstartDS/kickstartDS/pull/264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.4.3 to 2.4.4 [#261](https://github.com/kickstartDS/kickstartDS/pull/261) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @kickstartds/stylelint-config from 1.0.0 to 1.0.1 [#251](https://github.com/kickstartDS/kickstartDS/pull/251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @kickstartds/eslint-config from 1.0.0 to 1.0.1 [#250](https://github.com/kickstartDS/kickstartDS/pull/250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.5 to 6.3.6 [#249](https://github.com/kickstartDS/kickstartDS/pull/249) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump @commitlint/cli from 12.1.4 to 13.1.0 [#245](https://github.com/kickstartDS/kickstartDS/pull/245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.53.3 to 2.54.0 [#243](https://github.com/kickstartDS/kickstartDS/pull/243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/config-conventional from 12.1.4 to 13.1.0 [#242](https://github.com/kickstartDS/kickstartDS/pull/242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.1.0 to 11.1.1 [#240](https://github.com/kickstartDS/kickstartDS/pull/240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.0.1 to 11.1.0 [#234](https://github.com/kickstartDS/kickstartDS/pull/234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.4 to 6.3.5 [#229](https://github.com/kickstartDS/kickstartDS/pull/229) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump auto from 10.29.3 to 10.30.0 [#226](https://github.com/kickstartDS/kickstartDS/pull/226) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup from 2.53.2 to 2.53.3 [#223](https://github.com/kickstartDS/kickstartDS/pull/223) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.5 to 8.3.6 [#222](https://github.com/kickstartDS/kickstartDS/pull/222) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.6 to 5.0.7 [#221](https://github.com/kickstartDS/kickstartDS/pull/221) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.4.2 to 2.4.3 [#217](https://github.com/kickstartDS/kickstartDS/pull/217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/core from 7.14.6 to 7.14.8 [#219](https://github.com/kickstartDS/kickstartDS/pull/219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.14.7 to 7.14.8 [#220](https://github.com/kickstartDS/kickstartDS/pull/220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump eslint from 7.30.0 to 7.31.0 [#212](https://github.com/kickstartDS/kickstartDS/pull/212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @rollup/plugin-replace from 2.4.2 to 3.0.0 [#213](https://github.com/kickstartDS/kickstartDS/pull/213) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.53.1 to 2.53.2 [#210](https://github.com/kickstartDS/kickstartDS/pull/210) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump sass from 1.36.0 to 1.37.0 [#276](https://github.com/kickstartDS/kickstartDS/pull/276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.16 to 0.12.17 [#268](https://github.com/kickstartDS/kickstartDS/pull/268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.15 to 0.12.16 [#252](https://github.com/kickstartDS/kickstartDS/pull/252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.35.2 to 1.36.0 [#241](https://github.com/kickstartDS/kickstartDS/pull/241) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/content`
    - build(deps): bump countup.js from 2.0.7 to 2.0.8 [#262](https://github.com/kickstartDS/kickstartDS/pull/262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.14 to 17.0.15 [#244](https://github.com/kickstartDS/kickstartDS/pull/244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`
    - build(deps): bump date-fns from 2.22.1 to 2.23.0 [#235](https://github.com/kickstartDS/kickstartDS/pull/235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/runtime from 7.14.6 to 7.14.8 [#218](https://github.com/kickstartDS/kickstartDS/pull/218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
