### PR TITLE
fix invalid schemas

### DIFF
--- a/packages/components/base/source/1-atoms/button/link-button/link-button.schema.json
+++ b/packages/components/base/source/1-atoms/button/link-button/link-button.schema.json
@@ -9,7 +9,7 @@
       "type": "string",
       "title": "Button href?",
       "description": "Link used for button",
-      "format": "url",
+      "format": "uri",
       "default": "https://example.com"
     },
     "newTab": {

--- a/packages/components/blog/source/2-molecules/post-head/post-head.schema.json
+++ b/packages/components/blog/source/2-molecules/post-head/post-head.schema.json
@@ -6,6 +6,7 @@
   "type": "object",
   "properties": {
     "image": {
+      "type": "object",
       "allOf": [
         {
           "$ref": "http://frontend.ruhmesmeile.com/base/atoms/picture.definitions.json"

--- a/packages/components/blog/source/2-molecules/post-teaser/post-teaser.schema.json
+++ b/packages/components/blog/source/2-molecules/post-teaser/post-teaser.schema.json
@@ -13,6 +13,7 @@
       "default": "image-first"
     },
     "image": {
+      "type": "object",
       "allOf": [
         {
           "$ref": "http://frontend.ruhmesmeile.com/base/atoms/picture.definitions.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,7 +361,7 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.14.5", "@babel/helper-member-expression-to-functions@^7.14.7":
+"@babel/helper-member-expression-to-functions@^7.14.5":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
   integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==


### PR DESCRIPTION
fixes #303 
fixes #304
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.2.1-canary.305.1746.0
  npm install @kickstartds/blog@1.2.1-canary.305.1746.0
  npm install @kickstartds/content@1.2.1-canary.305.1746.0
  npm install @kickstartds/form@1.2.1-canary.305.1746.0
  # or 
  yarn add @kickstartds/base@1.2.1-canary.305.1746.0
  yarn add @kickstartds/blog@1.2.1-canary.305.1746.0
  yarn add @kickstartds/content@1.2.1-canary.305.1746.0
  yarn add @kickstartds/form@1.2.1-canary.305.1746.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.2.1-next.0`
`@kickstartds/blog@1.2.1-next.0`
`@kickstartds/content@1.2.1-next.0`
`@kickstartds/form@1.2.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@kickstartds/base`, `@kickstartds/blog`
    - fix invalid schemas [#305](https://github.com/kickstartDS/kickstartDS/pull/305) ([@lmestel](https://github.com/lmestel))
  
  #### Authors: 1
  
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
