### PR TITLE
fix text-media video size with caption

### DIFF
--- a/packages/components/base/source/0-base/1-tools/scss/_helpers.scss
+++ b/packages/components/base/source/0-base/1-tools/scss/_helpers.scss
@@ -103,25 +103,6 @@
   @return $string;
 }
 
-/// Detect IE Browsers
-
-@mixin browser($browser) {
-  // IE 11
-  @if $browser == 'ie11' {
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      @content;
-    }
-  }
-  // EDGE
-  @else if $browser == 'edge' {
-    @supports (-ms-ime-align: auto) {
-      @content;
-    }
-  } @else {
-    @content;
-  }
-}
-
 @mixin icon-color($color) {
   fill: $color;
 }

--- a/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
+++ b/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
@@ -1093,9 +1093,9 @@ export type GalleryIdentifier = string;
  */
 export type ID1 = string;
 /**
- * Additional Image Class
+ * Additional Class
  */
-export type AdditionalImageClass = string;
+export type AdditionalClass8 = string;
 /**
  * Display media item over full width
  */
@@ -1144,7 +1144,7 @@ export type ButtonSize7 = 'small' | 'medium' | 'large';
 export type AdditionalClasses11 = string;
 export type IconIdentifier8 = string;
 export type AriaRole8 = string;
-export type AdditionalClass8 = string;
+export type AdditionalClass9 = string;
 /**
  * Display icon before the button text
  */
@@ -1299,7 +1299,7 @@ export type ButtonSize8 = 'small' | 'medium' | 'large';
 export type AdditionalClasses13 = string;
 export type IconIdentifier9 = string;
 export type AriaRole9 = string;
-export type AdditionalClass9 = string;
+export type AdditionalClass10 = string;
 /**
  * Display icon before the button text
  */
@@ -1973,7 +1973,7 @@ export interface LazyLightboxImage {
   hideCaption?: HideCaptionVisually;
   gallery?: GalleryIdentifier;
   id?: ID1;
-  class?: AdditionalImageClass;
+  className?: AdditionalClass8;
   [k: string]: unknown;
 }
 /**
@@ -2012,7 +2012,7 @@ export interface LinkButton3 {
 export interface Icon8 {
   icon?: IconIdentifier8;
   role?: AriaRole8;
-  className?: AdditionalClass8;
+  className?: AdditionalClass9;
   [k: string]: unknown;
 }
 /**
@@ -2075,7 +2075,7 @@ export interface LinkButton4 {
 export interface Icon9 {
   icon?: IconIdentifier9;
   role?: AriaRole9;
-  className?: AdditionalClass9;
+  className?: AdditionalClass10;
   [k: string]: unknown;
 }
 /**

--- a/packages/components/base/source/1-atoms/iframe/IframeRatio.js
+++ b/packages/components/base/source/1-atoms/iframe/IframeRatio.js
@@ -6,13 +6,17 @@ export default class VideoIframe extends Component {
   constructor(element) {
     super(element);
 
-    const child = element.firstElementChild;
-    if (child && child.tagName === 'IFRAME') {
-      element.style.paddingTop = `${
-        (child.offsetHeight / child.offsetWidth) * 100
-      }%`;
-      element.style.width = `${child.offsetWidth}px`;
+    const iframe = element.firstElementChild;
+    if (iframe && iframe.tagName === 'IFRAME') {
+      const height = iframe.height || iframe.offsetHeight;
+      const width = iframe.width || iframe.offsetWidth;
+      element.style.paddingTop = `${(height / width) * 100}%`;
+      element.style.width = `${width}px`;
       element.classList.add('iframe-ratio--apsect-ratio-calculated');
+
+      if (element.dataset.autoWidth) {
+        element.parentElement.style.width = `min(${width}px, 100%)`;
+      }
     }
   }
 }

--- a/packages/components/base/source/1-atoms/iframe/IframeRatioComponent.tsx
+++ b/packages/components/base/source/1-atoms/iframe/IframeRatioComponent.tsx
@@ -7,6 +7,7 @@ type IframeRatioProps = {
   title?: string;
   width: number;
   height: number;
+  setParentWidth?: boolean;
 };
 
 export const IframeRatio: FunctionComponent<IframeRatioProps> = ({
@@ -14,8 +15,13 @@ export const IframeRatio: FunctionComponent<IframeRatioProps> = ({
   title,
   width,
   height,
+  setParentWidth,
 }) => (
-  <div className="iframe-ratio" data-component="base.iframe-ratio">
+  <div
+    className="iframe-ratio"
+    data-component="base.iframe-ratio"
+    data-auto-width={setParentWidth}
+  >
     <iframe
       allowFullScreen
       data-src={src}

--- a/packages/components/base/source/1-atoms/image/lightbox-image/LightboxLazyImageComponent.tsx
+++ b/packages/components/base/source/1-atoms/image/lightbox-image/LightboxLazyImageComponent.tsx
@@ -10,7 +10,7 @@ export const LightboxLazyImage: FunctionComponent<LazyLightboxImageProps> = ({
   image,
   thumb,
   zoomIcon,
-  class: imgClass,
+  className,
   gallery,
   width,
   height,
@@ -18,37 +18,35 @@ export const LightboxLazyImage: FunctionComponent<LazyLightboxImageProps> = ({
   caption,
   hideCaption,
 }) => (
-  <>
-    <figure
-      className={classnames(
-        'lightbox-image',
-        { 'lightbox-image--with-zoom-icon': zoomIcon },
-        imgClass
-      )}
-      itemScope={!!id}
+  <figure
+    className={classnames(
+      'lightbox-image',
+      { 'lightbox-image--with-zoom-icon': zoomIcon },
+      className
+    )}
+    itemScope={!!id}
+  >
+    <Link
+      href={image}
+      data-gallery={gallery}
+      data-size-w={width}
+      data-size-h={height}
+      className="lightbox-image__link js-open-lightbox"
+      title="Bild vergrößern"
     >
-      <Link
-        href={image}
-        data-gallery={gallery}
-        data-size-w={width}
-        data-size-h={height}
-        className="lightbox-image__link js-open-lightbox"
-        title="Bild vergrößern"
-      >
-        <Picture
-          src={thumb}
-          className={classnames('lightbox-image__thumb', imgClass)}
-          itemProp="image"
-        />
-        {zoomIcon ? (
-          <div className="lightbox-image__zoom-icon">
-            <Icon icon="zoom" role="img" />
-          </div>
-        ) : (
-          ''
-        )}
-      </Link>
-      {caption ? <figcaption hidden={hideCaption}>{caption}</figcaption> : ''}
-    </figure>
-  </>
+      <Picture
+        src={thumb}
+        className={classnames('lightbox-image__thumb', className)}
+        itemProp="image"
+      />
+      {zoomIcon ? (
+        <div className="lightbox-image__zoom-icon">
+          <Icon icon="zoom" role="img" />
+        </div>
+      ) : (
+        ''
+      )}
+    </Link>
+    {caption ? <figcaption hidden={hideCaption}>{caption}</figcaption> : ''}
+  </figure>
 );

--- a/packages/components/base/source/1-atoms/image/lightbox-image/LightboxLazyImageProps.ts
+++ b/packages/components/base/source/1-atoms/image/lightbox-image/LightboxLazyImageProps.ts
@@ -42,9 +42,9 @@ export type GalleryIdentifier = string;
  */
 export type ID = string;
 /**
- * Additional Image Class
+ * Additional Class
  */
-export type AdditionalImageClass = string;
+export type AdditionalClass = string;
 
 /**
  * Lazy Lightbox Image
@@ -59,6 +59,6 @@ export interface LazyLightboxImageProps {
   hideCaption?: HideCaptionVisually;
   gallery?: GalleryIdentifier;
   id?: ID;
-  class?: AdditionalImageClass;
+  className?: AdditionalClass;
   [k: string]: unknown;
 }

--- a/packages/components/base/source/1-atoms/image/lightbox-image/lightbox-lazy-image.definitions.json
+++ b/packages/components/base/source/1-atoms/image/lightbox-image/lightbox-lazy-image.definitions.json
@@ -61,10 +61,10 @@
       "title": "ID",
       "description": "ID"
     },
-    "class": {
+    "className": {
       "type": "string",
-      "title": "Additional Image Class",
-      "description": "Additional Image Class"
+      "title": "Additional Class",
+      "description": "Additional Class"
     }
   }
 }

--- a/packages/components/base/source/2-molecules/text-media/TextMediaComponent.tsx
+++ b/packages/components/base/source/2-molecules/text-media/TextMediaComponent.tsx
@@ -7,9 +7,12 @@ import { IframeRatio } from '../../1-atoms/iframe';
 import { RichText, defaultRenderFn } from '../../1-atoms/rich-text';
 import {
   TextMediaProps,
-  Video as IVideo,
-  Picture as IPicture,
-  LazyLightboxImage as ILightboxImage,
+  TextMediaVideo as IVideo,
+  TextMediaImage as IImage,
+  TextMediaLazyImage as ILightboxImage,
+  Media as IMedia,
+  FullWidthMedia as TFullWidthMedia,
+  Caption as TCaption,
 } from './TextMediaProps';
 import './text-media.scss';
 
@@ -17,59 +20,70 @@ export interface RenderFunctions {
   renderText?: renderFn;
 }
 
-type TMedia = Omit<TextMediaProps, 'text' | 'mediaAlignment'>;
-
-const WithCaption = ({ caption, children }) => (
-  <figure>
+const figureClassName = (full: TFullWidthMedia) =>
+  classnames('text-media__media', {
+    'text-media__media--full': full,
+  });
+const Figure: FunctionComponent<{
+  full?: TFullWidthMedia;
+  caption?: TCaption;
+}> = ({ full, caption, children }) => (
+  <figure className={figureClassName(full)}>
     {children}
-    {caption ? <figcaption>{caption}</figcaption> : ''}
+    {caption ? (
+      <figcaption className="text-media__caption">{caption}</figcaption>
+    ) : null}
   </figure>
 );
 
-const Video = ({ iframe, src, title, width, height }: IVideo) =>
-  iframe ? (
-    <IframeRatio
-      {...{
-        src,
-        title,
-        width,
-        height,
-      }}
-    />
-  ) : (
-    <>
-      <video controls className="lazyload" title={title} data-src={src}></video>
-      <noscript>
-        <video controls title={title} src={src}></video>
-      </noscript>
-    </>
-  );
+const Video: FunctionComponent<IVideo> = ({ full, caption, video }) => (
+  <Figure full={full} caption={caption}>
+    {video.iframe ? (
+      <IframeRatio {...video} setParentWidth={true} />
+    ) : (
+      <>
+        <video
+          controls
+          className="lazyload"
+          title={video.title}
+          data-src={video.src}
+        ></video>
+        <noscript>
+          <video controls title={video.title} src={video.src}></video>
+        </noscript>
+      </>
+    )}
+  </Figure>
+);
+const Image: FunctionComponent<IImage> = ({ full, caption, image }) => (
+  <Figure full={full} caption={caption}>
+    <Picture {...image} />
+  </Figure>
+);
+const LightboxImage: FunctionComponent<ILightboxImage> = ({
+  full,
+  caption,
+  lightboxImage,
+}) => (
+  <LightboxLazyImage
+    {...lightboxImage}
+    className={figureClassName(full)}
+    caption={lightboxImage.caption || caption}
+  />
+);
 
-const Media = ({ media }: TMedia) =>
-  media ? (
+const Media: FunctionComponent<{ media: IMedia }> = ({ media }) =>
+  media.length ? (
     <div className="text-media__gallery">
-      {media.map((m, i) => (
-        <div
-          className={classnames('text-media__media', {
-            'text-media__media--full': m.full,
-          })}
-          key={i}
-        >
-          {(m.video as IVideo)?.src ? (
-            <WithCaption caption={(m.video as IVideo).caption}>
-              <Video {...(m.video as IVideo)} />
-            </WithCaption>
-          ) : (m.image as IPicture)?.src ? (
-            <WithCaption caption={(m.image as IPicture).caption}>
-              <Picture {...(m.image as IPicture)} />
-            </WithCaption>
-          ) : (m.lightboxImage as ILightboxImage)?.image ? (
-            <LightboxLazyImage {...(m.lightboxImage as ILightboxImage)} />
-          ) : (
-            ''
-          )}
-        </div>
-      ))}
+      {media.map((m, i) =>
+        (m.video as IVideo)?.src ? (
+          <Video {...(m as IVideo)} key={i} />
+        ) : (m.image as IImage)?.src ? (
+          <Image {...(m as IImage)} key={i} />
+        ) : (m.lightboxImage as ILightboxImage)?.image ? (
+          <LightboxImage {...(m.lightboxImage as ILightboxImage)} key={i} />
+        ) : null
+      )}
     </div>
   ) : null;
 

--- a/packages/components/base/source/2-molecules/text-media/TextMediaProps.ts
+++ b/packages/components/base/source/2-molecules/text-media/TextMediaProps.ts
@@ -169,9 +169,9 @@ export type GalleryIdentifier = string;
  */
 export type ID = string;
 /**
- * Additional Image Class
+ * Additional Class
  */
-export type AdditionalImageClass = string;
+export type AdditionalClass = string;
 /**
  * Display media item over full width
  */
@@ -255,6 +255,6 @@ export interface LazyLightboxImage {
   hideCaption?: HideCaptionVisually;
   gallery?: GalleryIdentifier;
   id?: ID;
-  class?: AdditionalImageClass;
+  className?: AdditionalClass;
   [k: string]: unknown;
 }

--- a/packages/components/base/source/2-molecules/text-media/text-media.schema.json
+++ b/packages/components/base/source/2-molecules/text-media/text-media.schema.json
@@ -127,7 +127,8 @@
             "width": 300,
             "height": 300,
             "alt": "Square"
-          }
+          },
+          "caption": "Ut dolores quae sunt impedit et accusantium. Corrupti incidunt ullam reiciendis."
         }
       ]
     }

--- a/packages/components/base/source/2-molecules/text-media/text-media.scss
+++ b/packages/components/base/source/2-molecules/text-media/text-media.scss
@@ -1,16 +1,29 @@
 @use '../../0-base/1-tools/scss/aspect-ratio';
-@use '../../0-base/1-tools/scss/helpers';
 @use '@kickstartds/core/source/core/breakpoint';
 @use 'bourbon/core/bourbon';
 
 .text-media {
   @include bourbon.clearfix;
+  $gallery-gutter: 1rem;
+
+  &--beside {
+    .text-media__text {
+      @include breakpoint.media('≥s') {
+        overflow: hidden;
+      }
+
+      @include breakpoint.media('print') {
+        overflow: visible;
+      }
+    }
+  }
 
   &__gallery {
     @include bourbon.clearfix;
     display: flex;
     flex-wrap: wrap;
-    margin: -1rem 0 0 -1rem;
+    align-items: flex-start;
+    margin: ($gallery-gutter * -1) 0 0 ($gallery-gutter * -1);
 
     // above/below left (default), center, right
     .text-media--above & {
@@ -60,54 +73,29 @@
   }
 
   &__media {
-    padding: 1rem 0 0 1rem;
-    max-width: 100%;
-
-    &--full {
-      &,
-      > * {
-        width: 100vw !important;
-      }
-    }
-  }
-
-  &--beside {
-    .text-media__text {
-      @include breakpoint.media('≥s') {
-        overflow: hidden;
-      }
-
-      @include breakpoint.media('print') {
-        overflow: visible;
-      }
-    }
-  }
-
-  figure {
     display: table;
     table-layout: fixed;
+    padding: $gallery-gutter 0 0 $gallery-gutter;
+    max-width: 100%;
+    box-sizing: content-box;
 
-    @include helpers.browser(ie11) {
-      display: block;
+    &--full {
+      // width: 100vw !important;
+      &,
+      > * {
+        width: 100% !important;
+      }
     }
 
     a {
       display: table-cell;
-
-      @include helpers.browser(ie11) {
-        display: block;
-      }
     }
+  }
 
-    figcaption {
-      table-layout: fixed;
-      display: table-caption;
-      caption-side: bottom;
-      text-align: left;
-
-      @include helpers.browser(ie11) {
-        display: block;
-      }
-    }
+  &__caption {
+    display: table-caption;
+    caption-side: bottom;
+    text-align: left;
+    padding-left: $gallery-gutter;
   }
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.2.1-canary.332.1827.0
  npm install @kickstartds/blog@1.2.1-canary.332.1827.0
  npm install @kickstartds/content@1.2.1-canary.332.1827.0
  npm install @kickstartds/form@1.2.1-canary.332.1827.0
  # or 
  yarn add @kickstartds/base@1.2.1-canary.332.1827.0
  yarn add @kickstartds/blog@1.2.1-canary.332.1827.0
  yarn add @kickstartds/content@1.2.1-canary.332.1827.0
  yarn add @kickstartds/form@1.2.1-canary.332.1827.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.3.0-next.3`
`@kickstartds/blog@1.3.0-next.3`
`@kickstartds/content@1.3.0-next.4`
`@kickstartds/form@1.3.0-next.3`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`, `@kickstartds/core`
    - add scroll offset token [#328](https://github.com/kickstartDS/kickstartDS/pull/328) ([@lmestel](https://github.com/lmestel))
    - add table component [#279](https://github.com/kickstartDS/kickstartDS/pull/279) ([@lmestel](https://github.com/lmestel))
    - add rgb color tokens for button [#270](https://github.com/kickstartDS/kickstartDS/pull/270) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - add caption to text-media images & videos [#326](https://github.com/kickstartDS/kickstartDS/pull/326) ([@lmestel](https://github.com/lmestel))
    - add teaser padding token [#284](https://github.com/kickstartDS/kickstartDS/pull/284) ([@lmestel](https://github.com/lmestel))
    - add hide utilities to global styles [#277](https://github.com/kickstartDS/kickstartDS/pull/277) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`, `@kickstartds/core`
    - adjust spacing tokens [#283](https://github.com/kickstartDS/kickstartDS/pull/283) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`
    - add link tokens [#285](https://github.com/kickstartDS/kickstartDS/pull/285) ([@lmestel](https://github.com/lmestel))
    - add blog-teaser & blog-head [#224](https://github.com/kickstartDS/kickstartDS/pull/224) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`
    - add `styleAs` prop to headline [#280](https://github.com/kickstartDS/kickstartDS/pull/280) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`
    - add headline to visual [#163](https://github.com/kickstartDS/kickstartDS/pull/163) ([@julrich](https://github.com/julrich) [@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - add rgb color tokens [#269](https://github.com/kickstartDS/kickstartDS/pull/269) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/base`
    - fix text-media video size with caption [#332](https://github.com/kickstartDS/kickstartDS/pull/332) ([@lmestel](https://github.com/lmestel))
    - set icon button size relative to font-size [#286](https://github.com/kickstartDS/kickstartDS/pull/286) ([@lmestel](https://github.com/lmestel))
    - fix iframe alignment in TextMedia [#271](https://github.com/kickstartDS/kickstartDS/pull/271) ([@lmestel](https://github.com/lmestel))
    - Ci/component tokens [#259](https://github.com/kickstartDS/kickstartDS/pull/259) ([@lmestel](https://github.com/lmestel))
    - Ci/component tokens [#258](https://github.com/kickstartDS/kickstartDS/pull/258) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/content`
    - inherit visual headline alignment from box alignment [#329](https://github.com/kickstartDS/kickstartDS/pull/329) ([@lmestel](https://github.com/lmestel))
    - fix headline import [#298](https://github.com/kickstartDS/kickstartDS/pull/298) ([@lmestel](https://github.com/lmestel))
    - Hotfix/visual [#265](https://github.com/kickstartDS/kickstartDS/pull/265) ([@lmestel](https://github.com/lmestel))
    - fix visual content size with full size image [#260](https://github.com/kickstartDS/kickstartDS/pull/260) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/core`
    - move breakpoint css token to base.css [#327](https://github.com/kickstartDS/kickstartDS/pull/327) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`
    - fix invalid schemas [#305](https://github.com/kickstartDS/kickstartDS/pull/305) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - adjust spacing tokens [#300](https://github.com/kickstartDS/kickstartDS/pull/300) ([@lmestel](https://github.com/lmestel))
    - Revert "chore: trigger release" [#239](https://github.com/kickstartDS/kickstartDS/pull/239) ([@lmestel](https://github.com/lmestel))
    - chore: trigger release [#238](https://github.com/kickstartDS/kickstartDS/pull/238) ([@lmestel](https://github.com/lmestel))
    - fix: fix breakpoints parser [#216](https://github.com/kickstartDS/kickstartDS/pull/216) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`
    - set default button variant in visual to `outline-inverted` [#299](https://github.com/kickstartDS/kickstartDS/pull/299) ([@lmestel](https://github.com/lmestel))
    - fix: bring back visual slider nav [#257](https://github.com/kickstartDS/kickstartDS/pull/257) ([@lmestel](https://github.com/lmestel))
  
  #### 🏠 Internal
  
  - replace babel's loose option with assumptions [#291](https://github.com/kickstartDS/kickstartDS/pull/291) ([@lmestel](https://github.com/lmestel))
  - update vscode extension recommendations [#266](https://github.com/kickstartDS/kickstartDS/pull/266) ([@lmestel](https://github.com/lmestel))
  
  #### 📝 Documentation
  
  - add storybook-addon-html addon [#246](https://github.com/kickstartDS/kickstartDS/pull/246) ([@lmestel](https://github.com/lmestel))
  - add storybook darkmode addon [#292](https://github.com/kickstartDS/kickstartDS/pull/292) ([@lmestel](https://github.com/lmestel))
  - docs: remove storybook-addon-performance addon [#237](https://github.com/kickstartDS/kickstartDS/pull/237) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - add storybook design-tokens addon [#293](https://github.com/kickstartDS/kickstartDS/pull/293) ([@lmestel](https://github.com/lmestel))
    - storybook controls [#214](https://github.com/kickstartDS/kickstartDS/pull/214) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps-dev): bump auto from 10.30.0 to 10.31.0 [#324](https://github.com/kickstartDS/kickstartDS/pull/324) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.56.0 to 2.56.2 [#317](https://github.com/kickstartDS/kickstartDS/pull/317) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.1.1 to 11.1.2 [#308](https://github.com/kickstartDS/kickstartDS/pull/308) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.6 to 6.3.7 [#313](https://github.com/kickstartDS/kickstartDS/pull/313) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup from 2.55.1 to 2.56.0 [#295](https://github.com/kickstartDS/kickstartDS/pull/295) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/core from 7.14.8 to 7.15.0 [#290](https://github.com/kickstartDS/kickstartDS/pull/290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump eslint from 7.31.0 to 7.32.0 [#275](https://github.com/kickstartDS/kickstartDS/pull/275) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.14.8 to 7.14.9 [#273](https://github.com/kickstartDS/kickstartDS/pull/273) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.55.0 to 2.55.1 [#267](https://github.com/kickstartDS/kickstartDS/pull/267) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.54.0 to 2.55.0 [#264](https://github.com/kickstartDS/kickstartDS/pull/264) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.4.3 to 2.4.4 [#261](https://github.com/kickstartDS/kickstartDS/pull/261) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @kickstartds/stylelint-config from 1.0.0 to 1.0.1 [#251](https://github.com/kickstartDS/kickstartDS/pull/251) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @kickstartds/eslint-config from 1.0.0 to 1.0.1 [#250](https://github.com/kickstartDS/kickstartDS/pull/250) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.5 to 6.3.6 [#249](https://github.com/kickstartDS/kickstartDS/pull/249) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump @commitlint/cli from 12.1.4 to 13.1.0 [#245](https://github.com/kickstartDS/kickstartDS/pull/245) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.53.3 to 2.54.0 [#243](https://github.com/kickstartDS/kickstartDS/pull/243) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/config-conventional from 12.1.4 to 13.1.0 [#242](https://github.com/kickstartDS/kickstartDS/pull/242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.1.0 to 11.1.1 [#240](https://github.com/kickstartDS/kickstartDS/pull/240) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.0.1 to 11.1.0 [#234](https://github.com/kickstartDS/kickstartDS/pull/234) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.4 to 6.3.5 [#229](https://github.com/kickstartDS/kickstartDS/pull/229) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump auto from 10.29.3 to 10.30.0 [#226](https://github.com/kickstartDS/kickstartDS/pull/226) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup from 2.53.2 to 2.53.3 [#223](https://github.com/kickstartDS/kickstartDS/pull/223) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.5 to 8.3.6 [#222](https://github.com/kickstartDS/kickstartDS/pull/222) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.6 to 5.0.7 [#221](https://github.com/kickstartDS/kickstartDS/pull/221) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.4.2 to 2.4.3 [#217](https://github.com/kickstartDS/kickstartDS/pull/217) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/core from 7.14.6 to 7.14.8 [#219](https://github.com/kickstartDS/kickstartDS/pull/219) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.14.7 to 7.14.8 [#220](https://github.com/kickstartDS/kickstartDS/pull/220) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.17 to 17.0.18 [#330](https://github.com/kickstartDS/kickstartDS/pull/330) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.16 to 17.0.17 [#318](https://github.com/kickstartDS/kickstartDS/pull/318) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.15 to 17.0.16 [#296](https://github.com/kickstartDS/kickstartDS/pull/296) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.14 to 17.0.15 [#244](https://github.com/kickstartDS/kickstartDS/pull/244) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump esbuild from 0.12.19 to 0.12.20 [#322](https://github.com/kickstartDS/kickstartDS/pull/322) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.18 to 0.12.19 [#309](https://github.com/kickstartDS/kickstartDS/pull/309) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.17 to 0.12.18 [#297](https://github.com/kickstartDS/kickstartDS/pull/297) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.37.2 to 1.37.5 [#282](https://github.com/kickstartDS/kickstartDS/pull/282) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.37.0 to 1.37.2 [#278](https://github.com/kickstartDS/kickstartDS/pull/278) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.36.0 to 1.37.0 [#276](https://github.com/kickstartDS/kickstartDS/pull/276) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.16 to 0.12.17 [#268](https://github.com/kickstartDS/kickstartDS/pull/268) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.15 to 0.12.16 [#252](https://github.com/kickstartDS/kickstartDS/pull/252) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.35.2 to 1.36.0 [#241](https://github.com/kickstartDS/kickstartDS/pull/241) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/runtime from 7.14.8 to 7.15.3 [#319](https://github.com/kickstartDS/kickstartDS/pull/319) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump @babel/runtime from 7.14.6 to 7.14.8 [#218](https://github.com/kickstartDS/kickstartDS/pull/218) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/content`
    - build(deps): bump countup.js from 2.0.7 to 2.0.8 [#262](https://github.com/kickstartDS/kickstartDS/pull/262) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`
    - build(deps): bump date-fns from 2.22.1 to 2.23.0 [#235](https://github.com/kickstartDS/kickstartDS/pull/235) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
