### PR TITLE
fix mobile visual height

### DIFF
--- a/packages/components/content/source/2-molecules/visual/_visual-vars.scss
+++ b/packages/components/content/source/2-molecules/visual/_visual-vars.scss
@@ -4,7 +4,7 @@ $host: (
   '.c-visual': (
     background: null,
     min-height: (
-      xs: 20rem,
+      xs: 18rem,
       s: 21rem,
       m: 31.5rem,
       l: 35rem,

--- a/packages/components/content/source/2-molecules/visual/_visual__content.scss
+++ b/packages/components/content/source/2-molecules/visual/_visual__content.scss
@@ -6,14 +6,13 @@
   display: flex;
   align-items: center;
   width: 100%;
-  flex-grow: 1; // = 100% height
   margin: auto;
   /* critical:end */
 
   @include breakpoint.media('≥s') {
     /* critical:start */
     padding: var(--g-content-padding);
-    min-height: inherit; // ie fix
+    flex-grow: 1; // = 100% height
     /* critical:end */
   }
 

--- a/packages/components/content/source/2-molecules/visual/_visual__image.scss
+++ b/packages/components/content/source/2-molecules/visual/_visual__image.scss
@@ -29,9 +29,11 @@
 
   &,
   * {
-    /* critical:start */
-    min-height: inherit;
-    /* critical:end */
+    .c-visual--full & {
+      /* critical:start */
+      height: 100%;
+      /* critical:end */
+    }
   }
 
   img {

--- a/packages/components/content/source/2-molecules/visual/visual.scss
+++ b/packages/components/content/source/2-molecules/visual/visual.scss
@@ -37,6 +37,15 @@ $vars: meta.module-variables(visual-vars);
   &__media {
     /* critical:start */
     position: relative;
+
+    &,
+    * {
+      min-height: inherit;
+    }
+
+    .c-visual--full & {
+      flex-grow: 1;
+    }
     /* critical:end */
 
     @include breakpoint.media('≥s') {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.2.1-canary.344.1927.0
  npm install @kickstartds/blog@1.2.1-canary.344.1927.0
  npm install @kickstartds/content@1.2.1-canary.344.1927.0
  npm install @kickstartds/form@1.2.1-canary.344.1927.0
  # or 
  yarn add @kickstartds/base@1.2.1-canary.344.1927.0
  yarn add @kickstartds/blog@1.2.1-canary.344.1927.0
  yarn add @kickstartds/content@1.2.1-canary.344.1927.0
  yarn add @kickstartds/form@1.2.1-canary.344.1927.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.3.1-next.4`
`@kickstartds/blog@1.3.1-next.4`
`@kickstartds/content@1.3.1-next.5`
`@kickstartds/form@1.3.1-next.4`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`
    - add lightbox component [#341](https://github.com/kickstartDS/kickstartDS/pull/341) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/content`
    - fix mobile visual height [#344](https://github.com/kickstartDS/kickstartDS/pull/344) ([@lmestel](https://github.com/lmestel))
    - remove storytelling from critical styles [#338](https://github.com/kickstartDS/kickstartDS/pull/338) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - overwrite lightbox icon path [#342](https://github.com/kickstartDS/kickstartDS/pull/342) ([@lmestel](https://github.com/lmestel))
    - fix text-media gallery spacing [#337](https://github.com/kickstartDS/kickstartDS/pull/337) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump cssnano from 5.0.7 to 5.0.8 [#339](https://github.com/kickstartDS/kickstartDS/pull/339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.18 to 17.0.19 [#343](https://github.com/kickstartDS/kickstartDS/pull/343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump esbuild from 0.12.20 to 0.12.21 [#340](https://github.com/kickstartDS/kickstartDS/pull/340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
