### PR TITLE
add `className` property to section schema

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
+++ b/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
@@ -1364,6 +1364,10 @@ export type BottomSpacing4 = 'none' | 'small' | 'large';
  * Set the headline as a page header, triggering special css treatment
  */
 export type PageHeader4 = boolean;
+/**
+ * Add additional css classes that should be applied to the section
+ */
+export type AdditionalClass11 = string;
 
 export interface SectionProps {
   width?: 'full' | 'max' | 'wide' | 'default' | 'narrow';
@@ -1393,6 +1397,7 @@ export interface SectionProps {
   spaceBefore?: 'default' | 'small' | 'none';
   spaceAfter?: 'default' | 'small' | 'none';
   headline?: Headline4;
+  className?: AdditionalClass11;
   [k: string]: unknown;
 }
 export interface QuotesSlider {

--- a/packages/components/base/source/0-base/3-objects/section/section.schema.json
+++ b/packages/components/base/source/0-base/3-objects/section/section.schema.json
@@ -109,6 +109,11 @@
         },
         "headline": {
           "$ref": "http://frontend.ruhmesmeile.com/base/molecules/headline.schema.json"
+        },
+        "className": {
+          "type": "string",
+          "title": "Additional Class",
+          "description": "Add additional css classes that should be applied to the section"
         }
       }
     }


### PR DESCRIPTION
resolves #350
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.3.0-canary.352.1970.0
  npm install @kickstartds/blog@1.3.0-canary.352.1970.0
  npm install @kickstartds/content@1.3.0-canary.352.1970.0
  npm install @kickstartds/core@1.3.0-canary.352.1970.0
  npm install @kickstartds/form@1.3.0-canary.352.1970.0
  # or 
  yarn add @kickstartds/base@1.3.0-canary.352.1970.0
  yarn add @kickstartds/blog@1.3.0-canary.352.1970.0
  yarn add @kickstartds/content@1.3.0-canary.352.1970.0
  yarn add @kickstartds/core@1.3.0-canary.352.1970.0
  yarn add @kickstartds/form@1.3.0-canary.352.1970.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.3.1-next.6`
`@kickstartds/blog@1.3.1-next.6`
`@kickstartds/content@1.3.1-next.7`
`@kickstartds/form@1.3.1-next.6`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`
    - add `className` property to section schema [#352](https://github.com/kickstartDS/kickstartDS/pull/352) ([@lmestel](https://github.com/lmestel))
    - add lightbox component [#341](https://github.com/kickstartDS/kickstartDS/pull/341) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/base`, `@kickstartds/blog`
    - fix link button fill animation [#351](https://github.com/kickstartDS/kickstartDS/pull/351) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/content`
    - fix mobile visual height [#344](https://github.com/kickstartDS/kickstartDS/pull/344) ([@lmestel](https://github.com/lmestel))
    - remove storytelling from critical styles [#338](https://github.com/kickstartDS/kickstartDS/pull/338) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - overwrite lightbox icon path [#342](https://github.com/kickstartDS/kickstartDS/pull/342) ([@lmestel](https://github.com/lmestel))
    - fix text-media gallery spacing [#337](https://github.com/kickstartDS/kickstartDS/pull/337) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump rollup from 2.56.2 to 2.56.3 [#348](https://github.com/kickstartDS/kickstartDS/pull/348) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-csv from 3.0.6 to 4.0.0 [#345](https://github.com/kickstartDS/kickstartDS/pull/345) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.3.1 to 10.3.2 [#346](https://github.com/kickstartDS/kickstartDS/pull/346) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.7 to 5.0.8 [#339](https://github.com/kickstartDS/kickstartDS/pull/339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump sass from 1.38.0 to 1.38.1 [#349](https://github.com/kickstartDS/kickstartDS/pull/349) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.21 to 0.12.22 [#347](https://github.com/kickstartDS/kickstartDS/pull/347) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.20 to 0.12.21 [#340](https://github.com/kickstartDS/kickstartDS/pull/340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.18 to 17.0.19 [#343](https://github.com/kickstartDS/kickstartDS/pull/343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
