### PR TITLE
fix: optional src attribute for visual picture

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
+++ b/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
@@ -185,6 +185,10 @@ export type TabletImageSource = string;
  */
 export type DesktopImageSource = string;
 /**
+ * Override for img tag of picture element, if needed
+ */
+export type OptionalSource = string;
+/**
  * Choose to indent the image horizontally on small screens
  */
 export type ImageIndent = 'none' | 'left' | 'right';
@@ -367,6 +371,10 @@ export type TabletImageSource1 = string;
  * Background image source for large screens
  */
 export type DesktopImageSource1 = string;
+/**
+ * Override for img tag of picture element, if needed
+ */
+export type OptionalSource1 = string;
 /**
  * Choose to indent the image horizontally on small screens
  */
@@ -1515,6 +1523,7 @@ export interface BackgroundImage {
   srcMobile: MobileImageSource;
   srcTablet: TabletImageSource;
   srcDesktop: DesktopImageSource;
+  src?: OptionalSource;
   indent?: ImageIndent;
   alt?: AltText;
   [k: string]: unknown;
@@ -1628,6 +1637,7 @@ export interface BackgroundImage1 {
   srcMobile: MobileImageSource1;
   srcTablet: TabletImageSource1;
   srcDesktop: DesktopImageSource1;
+  src?: OptionalSource1;
   indent?: ImageIndent1;
   alt?: AltText1;
   [k: string]: unknown;

--- a/packages/components/content/source/2-molecules/visual-slider/VisualSliderProps.ts
+++ b/packages/components/content/source/2-molecules/visual-slider/VisualSliderProps.ts
@@ -27,6 +27,10 @@ export type TabletImageSource = string;
  */
 export type DesktopImageSource = string;
 /**
+ * Override for img tag of picture element, if needed
+ */
+export type OptionalSource = string;
+/**
  * Choose to indent the image horizontally on small screens
  */
 export type ImageIndent = 'none' | 'left' | 'right';
@@ -214,6 +218,7 @@ export interface BackgroundImage {
   srcMobile: MobileImageSource;
   srcTablet: TabletImageSource;
   srcDesktop: DesktopImageSource;
+  src?: OptionalSource;
   indent?: ImageIndent;
   alt?: AltText;
   [k: string]: unknown;

--- a/packages/components/content/source/2-molecules/visual/VisualMediaPartial.tsx
+++ b/packages/components/content/source/2-molecules/visual/VisualMediaPartial.tsx
@@ -10,7 +10,7 @@ interface IMedia extends MediaWrapper {
 }
 
 const Image: FunctionComponent<IMedia> = ({ image = {} }) => {
-  const { srcMobile, srcTablet, srcDesktop, indent, alt } = image;
+  const { srcMobile, srcTablet, srcDesktop, indent, alt, src } = image;
   const slide = useContext(SlideContext);
   return (
     <picture
@@ -25,7 +25,7 @@ const Image: FunctionComponent<IMedia> = ({ image = {} }) => {
           <source media="(min-width: 600px)" data-srcset={srcTablet} />
           <source data-srcset={srcMobile} />
           <Picture
-            src={srcMobile}
+            src={src || srcMobile}
             objectFit="cover"
             noscript={false}
             alt={alt}
@@ -38,7 +38,7 @@ const Image: FunctionComponent<IMedia> = ({ image = {} }) => {
           <source media="(min-width: 600px)" srcSet={srcTablet} />
           <source srcSet={srcMobile} />
           <Picture
-            src={srcMobile}
+            src={src || srcMobile}
             lazy={false}
             objectFit="cover"
             alt={alt}

--- a/packages/components/content/source/2-molecules/visual/VisualProps.ts
+++ b/packages/components/content/source/2-molecules/visual/VisualProps.ts
@@ -23,6 +23,10 @@ export type TabletImageSource = string;
  */
 export type DesktopImageSource = string;
 /**
+ * Override for img tag of picture element, if needed
+ */
+export type OptionalSource = string;
+/**
  * Choose to indent the image horizontally on small screens
  */
 export type ImageIndent = 'none' | 'left' | 'right';
@@ -197,6 +201,7 @@ export interface BackgroundImage {
   srcMobile: MobileImageSource;
   srcTablet: TabletImageSource;
   srcDesktop: DesktopImageSource;
+  src?: OptionalSource;
   indent?: ImageIndent;
   alt?: AltText;
   [k: string]: unknown;

--- a/packages/components/content/source/2-molecules/visual/visual.schema.json
+++ b/packages/components/content/source/2-molecules/visual/visual.schema.json
@@ -50,6 +50,13 @@
               "format": "image",
               "default": "https://picsum.photos/seed/kdsvisual/1920/810"
             },
+            "src": {
+              "title": "Optional source",
+              "description": "Override for img tag of picture element, if needed",
+              "type": "string",
+              "format": "image",
+              "default": "https://picsum.photos/seed/kdsvisual/640/270"
+            },
             "indent": {
               "title": "Image indent",
               "description": "Choose to indent the image horizontally on small screens",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.3.1-canary.367.2035.0
  npm install @kickstartds/blog@1.3.1-canary.367.2035.0
  npm install @kickstartds/content@1.3.1-canary.367.2035.0
  npm install @kickstartds/core@1.3.1-canary.367.2035.0
  npm install @kickstartds/form@1.3.1-canary.367.2035.0
  # or 
  yarn add @kickstartds/base@1.3.1-canary.367.2035.0
  yarn add @kickstartds/blog@1.3.1-canary.367.2035.0
  yarn add @kickstartds/content@1.3.1-canary.367.2035.0
  yarn add @kickstartds/core@1.3.1-canary.367.2035.0
  yarn add @kickstartds/form@1.3.1-canary.367.2035.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.3.1-next.8`
`@kickstartds/blog@1.3.1-next.8`
`@kickstartds/content@1.3.1-next.9`
`@kickstartds/core@1.3.1-next.4`
`@kickstartds/form@1.3.1-next.8`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`
    - add `className` property to section schema [#352](https://github.com/kickstartDS/kickstartDS/pull/352) ([@lmestel](https://github.com/lmestel))
    - add lightbox component [#341](https://github.com/kickstartDS/kickstartDS/pull/341) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/base`, `@kickstartds/content`
    - fix: optional src attribute for visual picture [#367](https://github.com/kickstartDS/kickstartDS/pull/367) ([@julrich](https://github.com/julrich))
  - `@kickstartds/base`, `@kickstartds/blog`
    - fix link button fill animation [#351](https://github.com/kickstartDS/kickstartDS/pull/351) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/content`
    - fix mobile visual height [#344](https://github.com/kickstartDS/kickstartDS/pull/344) ([@lmestel](https://github.com/lmestel))
    - remove storytelling from critical styles [#338](https://github.com/kickstartDS/kickstartDS/pull/338) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - overwrite lightbox icon path [#342](https://github.com/kickstartDS/kickstartDS/pull/342) ([@lmestel](https://github.com/lmestel))
    - fix text-media gallery spacing [#337](https://github.com/kickstartDS/kickstartDS/pull/337) ([@lmestel](https://github.com/lmestel))
  
  #### ⚠️ Pushed to `next`
  
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - Merge branch 'master' into next ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps-dev): bump vite from 2.5.0 to 2.5.2 [#364](https://github.com/kickstartDS/kickstartDS/pull/364) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-ts from 1.4.0 to 1.4.1 [#365](https://github.com/kickstartDS/kickstartDS/pull/365) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-csv from 4.0.0 to 4.0.2 [#363](https://github.com/kickstartDS/kickstartDS/pull/363) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump typescript from 4.3.5 to 4.4.2 [#356](https://github.com/kickstartDS/kickstartDS/pull/356) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.3.2 to 10.3.3 [#359](https://github.com/kickstartDS/kickstartDS/pull/359) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump husky from 7.0.1 to 7.0.2 [#354](https://github.com/kickstartDS/kickstartDS/pull/354) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.56.2 to 2.56.3 [#348](https://github.com/kickstartDS/kickstartDS/pull/348) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-csv from 3.0.6 to 4.0.0 [#345](https://github.com/kickstartDS/kickstartDS/pull/345) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.3.1 to 10.3.2 [#346](https://github.com/kickstartDS/kickstartDS/pull/346) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.7 to 5.0.8 [#339](https://github.com/kickstartDS/kickstartDS/pull/339) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump sass from 1.38.2 to 1.39.0 [#369](https://github.com/kickstartDS/kickstartDS/pull/369) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.23 to 0.12.24 [#361](https://github.com/kickstartDS/kickstartDS/pull/361) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.38.1 to 1.38.2 [#362](https://github.com/kickstartDS/kickstartDS/pull/362) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.22 to 0.12.23 [#355](https://github.com/kickstartDS/kickstartDS/pull/355) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.38.0 to 1.38.1 [#349](https://github.com/kickstartDS/kickstartDS/pull/349) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.21 to 0.12.22 [#347](https://github.com/kickstartDS/kickstartDS/pull/347) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.20 to 0.12.21 [#340](https://github.com/kickstartDS/kickstartDS/pull/340) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps): bump react-markdown from 7.0.0 to 7.0.1 [#357](https://github.com/kickstartDS/kickstartDS/pull/357) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.18 to 17.0.19 [#343](https://github.com/kickstartDS/kickstartDS/pull/343) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 3
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
