### PR TITLE
don't render empty section headline

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
+++ b/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
@@ -57,7 +57,7 @@ const SectionComponent: FunctionComponent<
     )}
     {...props}
   >
-    {headline && (
+    {headline && headline.content && (
       <Container width={width}>
         <Headline {...headline} />
       </Container>


### PR DESCRIPTION
resolves  #307
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.3.1-canary.385.2103.0
  npm install @kickstartds/blog@1.3.1-canary.385.2103.0
  npm install @kickstartds/content@1.3.1-canary.385.2103.0
  npm install @kickstartds/form@1.3.1-canary.385.2103.0
  # or 
  yarn add @kickstartds/base@1.3.1-canary.385.2103.0
  yarn add @kickstartds/blog@1.3.1-canary.385.2103.0
  yarn add @kickstartds/content@1.3.1-canary.385.2103.0
  yarn add @kickstartds/form@1.3.1-canary.385.2103.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
