### PR TITLE
fix table component rerender

### DIFF
--- a/packages/components/base/source/1-atoms/table/TableComponent.tsx
+++ b/packages/components/base/source/1-atoms/table/TableComponent.tsx
@@ -20,7 +20,7 @@ const TableComponent: FunctionComponent<
   TableProps & RenderFunctions & HTMLAttributes<HTMLTableElement>
 > = ({
   caption,
-  rows,
+  rows = [],
   colHead,
   rowHead,
   responsive,
@@ -30,45 +30,49 @@ const TableComponent: FunctionComponent<
   renderCell = defaultRenderFn,
   renderCaption = defaultRenderFn,
   ...props
-}) => (
-  <table
-    className={classnames(
-      'c-table',
-      {
-        'c-table--responsive': responsive,
-        'c-table--border': variant === 'border',
-        'c-table--zebra': variant === 'zebra',
-      },
-      className
-    )}
-    {...props}
-    data-component={responsive ? 'base.responsive-table' : null}
-  >
-    {caption && <caption>{renderCaption(caption)}</caption>}
-    {rowHead && (
-      <thead>
-        <tr>
-          {rows?.shift().map((cell, index) => (
-            <th key={index}>{renderHead(cell)}</th>
-          ))}
-        </tr>
-      </thead>
-    )}
-    <tbody>
-      {rows?.map((row, rowIndex) => (
-        <tr key={rowIndex}>
-          {row?.map((cell, cellIndex) =>
-            colHead && cellIndex === 0 ? (
-              <th key={`${rowIndex}-${cellIndex}`}>{renderHead(cell)}</th>
-            ) : (
-              <td key={`${rowIndex}-${cellIndex}`}>{renderCell(cell)}</td>
-            )
-          )}
-        </tr>
-      ))}
-    </tbody>
-  </table>
-);
+}) => {
+  const bodyRows = [...rows];
+  const headRows = rowHead ? bodyRows.shift() : [];
+  return (
+    <table
+      className={classnames(
+        'c-table',
+        {
+          'c-table--responsive': responsive,
+          'c-table--border': variant === 'border',
+          'c-table--zebra': variant === 'zebra',
+        },
+        className
+      )}
+      {...props}
+      data-component={responsive ? 'base.responsive-table' : null}
+    >
+      {caption && <caption>{renderCaption(caption)}</caption>}
+      {rowHead && (
+        <thead>
+          <tr>
+            {headRows.map((cell, index) => (
+              <th key={index}>{renderHead(cell)}</th>
+            ))}
+          </tr>
+        </thead>
+      )}
+      <tbody>
+        {bodyRows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            {row.map((cell, cellIndex) =>
+              colHead && cellIndex === 0 ? (
+                <th key={`${rowIndex}-${cellIndex}`}>{renderHead(cell)}</th>
+              ) : (
+                <td key={`${rowIndex}-${cellIndex}`}>{renderCell(cell)}</td>
+              )
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 export const TableContextDefault = TableComponent;
 export const TableContext = createContext(TableContextDefault);


### PR DESCRIPTION
by not mutating the original `rows`-prop
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.4.1-canary.405.2193.0
  npm install @kickstartds/blog@1.4.1-canary.405.2193.0
  npm install @kickstartds/content@1.4.1-canary.405.2193.0
  npm install @kickstartds/core@1.4.1-canary.405.2193.0
  npm install @kickstartds/form@1.4.1-canary.405.2193.0
  # or 
  yarn add @kickstartds/base@1.4.1-canary.405.2193.0
  yarn add @kickstartds/blog@1.4.1-canary.405.2193.0
  yarn add @kickstartds/content@1.4.1-canary.405.2193.0
  yarn add @kickstartds/core@1.4.1-canary.405.2193.0
  yarn add @kickstartds/form@1.4.1-canary.405.2193.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.5.0-next.1`
`@kickstartds/blog@1.5.0-next.1`
`@kickstartds/content@1.5.0-next.1`
`@kickstartds/core@1.5.0-next.1`
`@kickstartds/form@1.5.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`
    - add render functions to table [#402](https://github.com/kickstartDS/kickstartDS/pull/402) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/base`
    - fix table component rerender [#405](https://github.com/kickstartDS/kickstartDS/pull/405) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - add `className` to any schema [#392](https://github.com/kickstartDS/kickstartDS/pull/392) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump typescript from 4.4.2 to 4.4.3 [#394](https://github.com/kickstartDS/kickstartDS/pull/394) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-schema-to-typescript from 10.1.4 to 10.1.5 [#396](https://github.com/kickstartDS/kickstartDS/pull/396) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.15.4 to 7.15.6 [#390](https://github.com/kickstartDS/kickstartDS/pull/390) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump prettier from 2.3.2 to 2.4.0 [#391](https://github.com/kickstartDS/kickstartDS/pull/391) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump sass from 1.40.0 to 1.41.0 [#403](https://github.com/kickstartDS/kickstartDS/pull/403) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.39.2 to 1.40.0 [#400](https://github.com/kickstartDS/kickstartDS/pull/400) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.27 to 0.12.28 [#399](https://github.com/kickstartDS/kickstartDS/pull/399) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.26 to 0.12.27 [#395](https://github.com/kickstartDS/kickstartDS/pull/395) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.25 to 0.12.26 [#389](https://github.com/kickstartDS/kickstartDS/pull/389) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.39.0 to 1.39.2 [#388](https://github.com/kickstartDS/kickstartDS/pull/388) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.20 to 17.0.21 [#404](https://github.com/kickstartDS/kickstartDS/pull/404) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
