### PR TITLE
add context structure to more components

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
+++ b/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
@@ -2,6 +2,7 @@ import {
   FunctionComponent,
   createContext,
   useContext,
+  createElement,
   HTMLAttributes,
 } from 'react';
 import classnames from 'classnames';
@@ -72,7 +73,5 @@ const SectionComponent: FunctionComponent<
 
 export const SectionContextDefault = SectionComponent;
 export const SectionContext = createContext(SectionContextDefault);
-export const Section: typeof SectionContextDefault = (props) => {
-  const Component = useContext(SectionContext);
-  return <Component {...props} />;
-};
+export const Section: typeof SectionContextDefault = (props) =>
+  createElement(useContext(SectionContext), props);

--- a/packages/components/base/source/1-atoms/button/button/ButtonComponent.tsx
+++ b/packages/components/base/source/1-atoms/button/button/ButtonComponent.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   createContext,
   useContext,
+  createElement,
   ButtonHTMLAttributes,
 } from 'react';
 import classnames from 'classnames';
@@ -63,7 +64,6 @@ const ButtonComponent: ForwardRefRenderFunction<
 
 export const ButtonContextDefault = forwardRef(ButtonComponent);
 export const ButtonContext = createContext(ButtonContextDefault);
-export const Button: typeof ButtonContextDefault = forwardRef((props, ref) => {
-  const Component = useContext(ButtonContext);
-  return <Component {...props} ref={ref} />;
-});
+export const Button: typeof ButtonContextDefault = forwardRef((props, ref) =>
+  createElement(useContext(ButtonContext), { ...props, ref })
+);

--- a/packages/components/base/source/1-atoms/button/link-button/LinkButtonComponent.tsx
+++ b/packages/components/base/source/1-atoms/button/link-button/LinkButtonComponent.tsx
@@ -3,6 +3,7 @@ import {
   forwardRef,
   createContext,
   useContext,
+  createElement,
   AnchorHTMLAttributes,
 } from 'react';
 import classnames from 'classnames';
@@ -73,8 +74,6 @@ const LinkButtonComponent: ForwardRefRenderFunction<
 export const LinkButtonContextDefault = forwardRef(LinkButtonComponent);
 export const LinkButtonContext = createContext(LinkButtonContextDefault);
 export const LinkButton: typeof LinkButtonContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(LinkButtonContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) =>
+    createElement(useContext(LinkButtonContext), { ...props, ref })
 );

--- a/packages/components/base/source/1-atoms/divider/DividerComponent.tsx
+++ b/packages/components/base/source/1-atoms/divider/DividerComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   createContext,
   useContext,
+  createElement,
   HTMLAttributes,
 } from 'react';
 import { DividerProps } from './DividerProps';
@@ -23,7 +24,5 @@ const DividerComponent: FunctionComponent<
 
 export const DividerContextDefault = DividerComponent;
 export const DividerContext = createContext(DividerContextDefault);
-export const Divider: typeof DividerContextDefault = (props) => {
-  const Component = useContext(DividerContext);
-  return <Component {...props} />;
-};
+export const Divider: typeof DividerContextDefault = (props) =>
+  createElement(useContext(DividerContext), props);

--- a/packages/components/base/source/1-atoms/html/HtmlComponent.tsx
+++ b/packages/components/base/source/1-atoms/html/HtmlComponent.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   createContext,
   useContext,
+  createElement,
 } from 'react';
 import classNames from 'classnames';
 import { HTMLProps } from './HtmlProps';
@@ -19,7 +20,5 @@ export const HtmlComponent: FunctionComponent<
 
 export const HtmlContextDefault = HtmlComponent;
 export const HtmlContext = createContext(HtmlContextDefault);
-export const Html: typeof HtmlContextDefault = (props) => {
-  const Component = useContext(HtmlContext);
-  return <Component {...props} />;
-};
+export const Html: typeof HtmlContextDefault = (props) =>
+  createElement(useContext(HtmlContext), props);

--- a/packages/components/base/source/1-atoms/icon/IconComponent.tsx
+++ b/packages/components/base/source/1-atoms/icon/IconComponent.tsx
@@ -1,10 +1,8 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, createElement } from 'react';
 import './icon.scss';
 import { Icon as IconComponent } from './PureIconComponent';
 
 export const IconContextDefault = IconComponent;
 export const IconContext = createContext(IconContextDefault);
-export const Icon: typeof IconContextDefault = (props) => {
-  const Component = useContext(IconContext);
-  return <Component {...props} />;
-};
+export const Icon: typeof IconContextDefault = (props) =>
+  createElement(useContext(IconContext), props);

--- a/packages/components/base/source/1-atoms/iframe/IframeRatioComponent.tsx
+++ b/packages/components/base/source/1-atoms/iframe/IframeRatioComponent.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   createContext,
   useContext,
+  createElement,
 } from 'react';
 import classNames from 'classnames';
 import './iframe-ratio.scss';
@@ -38,7 +39,5 @@ export const IframeRatioComponent: FunctionComponent<
 
 export const IframeRatioContextDefault = IframeRatioComponent;
 export const IframeRatioContext = createContext(IframeRatioContextDefault);
-export const IframeRatio: typeof IframeRatioContextDefault = (props) => {
-  const Component = useContext(IframeRatioContext);
-  return <Component {...props} />;
-};
+export const IframeRatio: typeof IframeRatioContextDefault = (props) =>
+  createElement(useContext(IframeRatioContext), props);

--- a/packages/components/base/source/1-atoms/image/picture/PictureComponent.tsx
+++ b/packages/components/base/source/1-atoms/image/picture/PictureComponent.tsx
@@ -6,6 +6,7 @@ import {
   createContext,
   Ref,
   useContext,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { PictureProps } from './PictureProps';
@@ -70,9 +71,6 @@ const PictureComponent: ForwardRefRenderFunction<
 
 export const PictureContextDefault = forwardRef(PictureComponent);
 export const PictureContext = createContext(PictureContextDefault);
-export const Picture: typeof PictureContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(PictureContext);
-    return <Component {...props} ref={ref} />;
-  }
+export const Picture: typeof PictureContextDefault = forwardRef((props, ref) =>
+  createElement(useContext(PictureContext), { ...props, ref })
 );

--- a/packages/components/base/source/1-atoms/link/LinkComponent.tsx
+++ b/packages/components/base/source/1-atoms/link/LinkComponent.tsx
@@ -5,6 +5,7 @@ import {
   createContext,
   useContext,
   Ref,
+  createElement,
 } from 'react';
 
 type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
@@ -22,7 +23,6 @@ const LinkComponent: ForwardRefRenderFunction<HTMLAnchorElement, LinkProps> = (
 
 export const LinkContextDefault = forwardRef(LinkComponent);
 export const LinkContext = createContext(LinkContextDefault);
-export const Link: typeof LinkContextDefault = forwardRef((props, ref) => {
-  const Compnent = useContext(LinkContext);
-  return <Compnent {...props} ref={ref} />;
-});
+export const Link: typeof LinkContextDefault = forwardRef((props, ref) =>
+  createElement(useContext(LinkContext), { ...props, ref })
+);

--- a/packages/components/base/source/1-atoms/rich-text/RichTextComponent.tsx
+++ b/packages/components/base/source/1-atoms/rich-text/RichTextComponent.tsx
@@ -2,6 +2,7 @@ import {
   FunctionComponent,
   createContext,
   useContext,
+  createElement,
   HTMLAttributes,
 } from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -28,7 +29,5 @@ const RichTextComponent: FunctionComponent<
 
 export const RichTextContextDefault = RichTextComponent;
 export const RichTextContext = createContext(RichTextContextDefault);
-export const RichText: typeof RichTextContextDefault = (props) => {
-  const Component = useContext(RichTextContext);
-  return <Component {...props} />;
-};
+export const RichText: typeof RichTextContextDefault = (props) =>
+  createElement(useContext(RichTextContext), props);

--- a/packages/components/base/source/1-atoms/table/TableComponent.tsx
+++ b/packages/components/base/source/1-atoms/table/TableComponent.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -76,7 +77,5 @@ const TableComponent: FunctionComponent<
 
 export const TableContextDefault = TableComponent;
 export const TableContext = createContext(TableContextDefault);
-export const Table: typeof TableContextDefault = (props) => {
-  const Compnent = useContext(TableContext);
-  return <Compnent {...props} />;
-};
+export const Table: typeof TableContextDefault = (props) =>
+  createElement(useContext(TableContext), props);

--- a/packages/components/base/source/1-atoms/tag-label/TagLabelComponent.tsx
+++ b/packages/components/base/source/1-atoms/tag-label/TagLabelComponent.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -49,7 +50,5 @@ const TagLabelComponent: FunctionComponent<
 
 export const TagLabelContextDefault = TagLabelComponent;
 export const TagLabelContext = createContext(TagLabelContextDefault);
-export const TagLabel: typeof TagLabelContextDefault = (props) => {
-  const Component = useContext(TagLabelContext);
-  return <Component {...props} />;
-};
+export const TagLabel: typeof TagLabelContextDefault = (props) =>
+  createElement(useContext(TagLabelContext), props);

--- a/packages/components/base/source/2-molecules/content-box/ContentBoxComponent.tsx
+++ b/packages/components/base/source/2-molecules/content-box/ContentBoxComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -72,7 +73,5 @@ const ContentBoxComponent: FunctionComponent<
 
 export const ContentBoxContextDefault = ContentBoxComponent;
 export const ContentBoxContext = createContext(ContentBoxContextDefault);
-export const ContentBox: typeof ContentBoxContextDefault = (props) => {
-  const Component = useContext(ContentBoxContext);
-  return <Component {...props} />;
-};
+export const ContentBox: typeof ContentBoxContextDefault = (props) =>
+  createElement(useContext(ContentBoxContext), props);

--- a/packages/components/base/source/2-molecules/headline/HeadlineComponent.tsx
+++ b/packages/components/base/source/2-molecules/headline/HeadlineComponent.tsx
@@ -2,6 +2,7 @@ import {
   FunctionComponent,
   createContext,
   useContext,
+  createElement,
   HTMLAttributes,
 } from 'react';
 import classnames from 'classnames';
@@ -60,7 +61,5 @@ const HeadlineComponent: FunctionComponent<
 
 export const HeadlineContextDefault = HeadlineComponent;
 export const HeadlineContext = createContext(HeadlineContextDefault);
-export const Headline: typeof HeadlineContextDefault = (props) => {
-  const Component = useContext(HeadlineContext);
-  return <Component {...props} />;
-};
+export const Headline: typeof HeadlineContextDefault = (props) =>
+  createElement(useContext(HeadlineContext), props);

--- a/packages/components/base/source/2-molecules/tag-label-container/TagLabelContainerComponent.tsx
+++ b/packages/components/base/source/2-molecules/tag-label-container/TagLabelContainerComponent.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   createContext,
   useContext,
+  createElement,
 } from 'react';
 import classNames from 'classnames';
 import { TagLabel, TagLabelProps } from '../../1-atoms/tag-label';
@@ -30,7 +31,4 @@ export const TagLabelContainerContext = createContext(
 );
 export const TagLabelContainer: typeof TagLabelContainerContextDefault = (
   props
-) => {
-  const Component = useContext(TagLabelContainerContext);
-  return <Component {...props} />;
-};
+) => createElement(useContext(TagLabelContainerContext), props);

--- a/packages/components/base/source/2-molecules/teaser-box/TeaserBoxComponent.tsx
+++ b/packages/components/base/source/2-molecules/teaser-box/TeaserBoxComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { Picture } from '../../1-atoms/image/picture';
@@ -38,7 +39,5 @@ const TeaserBoxComponent: FunctionComponent<
 
 export const TeaserBoxContextDefault = TeaserBoxComponent;
 export const TeaserBoxContext = createContext(TeaserBoxContextDefault);
-export const TeaserBox: typeof TeaserBoxContextDefault = (props) => {
-  const Component = useContext(TeaserBoxContext);
-  return <Component {...props} />;
-};
+export const TeaserBox: typeof TeaserBoxContextDefault = (props) =>
+  createElement(useContext(TeaserBoxContext), props);

--- a/packages/components/base/source/2-molecules/teaser-row/TeaserRowComponent.tsx
+++ b/packages/components/base/source/2-molecules/teaser-row/TeaserRowComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { TeaserRowProps } from './TeaserRowProps';
@@ -17,7 +18,5 @@ const TeaserRowComponent: FunctionComponent<
 
 export const TeaserRowContextDefault = TeaserRowComponent;
 export const TeaserRowContext = createContext(TeaserRowContextDefault);
-export const TeaserRow: typeof TeaserRowContextDefault = (props) => {
-  const Component = useContext(TeaserRowContext);
-  return <Component {...props} />;
-};
+export const TeaserRow: typeof TeaserRowContextDefault = (props) =>
+  createElement(useContext(TeaserRowContext), props);

--- a/packages/components/base/source/2-molecules/teaser/TeaserComponent.tsx
+++ b/packages/components/base/source/2-molecules/teaser/TeaserComponent.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   createContext,
   useContext,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -66,7 +67,5 @@ export const TeaserComponent: FunctionComponent<
 
 export const TeaserContextDefault = TeaserComponent;
 export const TeaserContext = createContext(TeaserContextDefault);
-export const Teaser: typeof TeaserContextDefault = (props) => {
-  const Component = useContext(TeaserContext);
-  return <Component {...props} />;
-};
+export const Teaser: typeof TeaserContextDefault = (props) =>
+  createElement(useContext(TeaserContext), props);

--- a/packages/components/base/source/2-molecules/text-media/TextMediaComponent.tsx
+++ b/packages/components/base/source/2-molecules/text-media/TextMediaComponent.tsx
@@ -3,6 +3,7 @@ import {
   HTMLAttributes,
   createContext,
   useContext,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn } from '@kickstartds/core/lib/core';
@@ -145,7 +146,5 @@ export const TextMediaComponent: FunctionComponent<
 
 export const TextMediaContextDefault = TextMediaComponent;
 export const TextMediaContext = createContext(TextMediaContextDefault);
-export const TextMedia: typeof TextMediaContextDefault = (props) => {
-  const Component = useContext(TextMediaContext);
-  return <Component {...props} />;
-};
+export const TextMedia: typeof TextMediaContextDefault = (props) =>
+  createElement(useContext(TextMediaContext), props);

--- a/packages/components/blog/source/2-molecules/post-head/PostHeadComponent.tsx
+++ b/packages/components/blog/source/2-molecules/post-head/PostHeadComponent.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   FunctionComponent,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classNames from 'classnames';
 import { format } from 'date-fns';
@@ -59,7 +60,5 @@ const PostHeadComponent: FunctionComponent<
 
 export const PostHeadContextDefault = PostHeadComponent;
 export const PostHeadContext = createContext(PostHeadContextDefault);
-export const PostHead: typeof PostHeadContextDefault = (props) => {
-  const Component = useContext(PostHeadContext);
-  return <Component {...props} />;
-};
+export const PostHead: typeof PostHeadContextDefault = (props) =>
+  createElement(useContext(PostHeadContext), props);

--- a/packages/components/blog/source/2-molecules/post-teaser/PostTeaserComponent.tsx
+++ b/packages/components/blog/source/2-molecules/post-teaser/PostTeaserComponent.tsx
@@ -3,6 +3,7 @@ import {
   useContext,
   FunctionComponent,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import { format } from 'date-fns';
 import classnames from 'classnames';
@@ -130,7 +131,5 @@ const PostTeaserComponent: FunctionComponent<
 
 export const PostTeaserContextDefault = PostTeaserComponent;
 export const PostTeaserContext = createContext(PostTeaserContextDefault);
-export const PostTeaser: typeof PostTeaserContextDefault = (props) => {
-  const Component = useContext(PostTeaserContext);
-  return <Component {...props} />;
-};
+export const PostTeaser: typeof PostTeaserContextDefault = (props) =>
+  createElement(useContext(PostTeaserContext), props);

--- a/packages/components/content/source/2-molecules/collapsible-box/CollapsibleBoxComponent.tsx
+++ b/packages/components/content/source/2-molecules/collapsible-box/CollapsibleBoxComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -66,7 +67,5 @@ export const CollapsibleBoxContextDefault = CollapsibleBoxComponent;
 export const CollapsibleBoxContext = createContext(
   CollapsibleBoxContextDefault
 );
-export const CollapsibleBox: typeof CollapsibleBoxContextDefault = (props) => {
-  const Component = useContext(CollapsibleBoxContext);
-  return <Component {...props} />;
-};
+export const CollapsibleBox: typeof CollapsibleBoxContextDefault = (props) =>
+  createElement(useContext(CollapsibleBoxContext), props);

--- a/packages/components/content/source/2-molecules/contact/ContactComponent.tsx
+++ b/packages/components/content/source/2-molecules/contact/ContactComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { Picture } from '@kickstartds/base/lib/picture';
@@ -62,7 +63,5 @@ const ContactComponent: FunctionComponent<
 
 export const ContactContextDefault = ContactComponent;
 export const ContactContext = createContext(ContactContextDefault);
-export const Contact: typeof ContactContextDefault = (props) => {
-  const Component = useContext(ContactContext);
-  return <Component {...props} />;
-};
+export const Contact: typeof ContactContextDefault = (props) =>
+  createElement(useContext(ContactContext), props);

--- a/packages/components/content/source/2-molecules/count-up/CountUpComponent.tsx
+++ b/packages/components/content/source/2-molecules/count-up/CountUpComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import {
@@ -82,7 +83,5 @@ const CountUpComponent: FunctionComponent<
 
 export const CountUpContextDefault = CountUpComponent;
 export const CountUpContext = createContext(CountUpContextDefault);
-export const CountUp: typeof CountUpContextDefault = (props) => {
-  const Component = useContext(CountUpContext);
-  return <Component {...props} />;
-};
+export const CountUp: typeof CountUpContextDefault = (props) =>
+  createElement(useContext(CountUpContext), props);

--- a/packages/components/content/source/2-molecules/logo-tiles/LogoTilesComponent.tsx
+++ b/packages/components/content/source/2-molecules/logo-tiles/LogoTilesComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { Picture } from '@kickstartds/base/lib/picture';
@@ -24,7 +25,5 @@ const LogoTilesComponent: FunctionComponent<
 
 export const LogoTilesContextDefault = LogoTilesComponent;
 export const LogoTilesContext = createContext(LogoTilesContextDefault);
-export const LogoTiles: typeof LogoTilesContextDefault = (props) => {
-  const Component = useContext(LogoTilesContext);
-  return <Component {...props} />;
-};
+export const LogoTiles: typeof LogoTilesContextDefault = (props) =>
+  createElement(useContext(LogoTilesContext), props);

--- a/packages/components/content/source/2-molecules/quote/QuoteComponent.tsx
+++ b/packages/components/content/source/2-molecules/quote/QuoteComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -53,7 +54,5 @@ const QuoteComponent: FunctionComponent<
 
 export const QuoteContextDefault = QuoteComponent;
 export const QuoteContext = createContext(QuoteContextDefault);
-export const Quote: typeof QuoteContextDefault = (props) => {
-  const Component = useContext(QuoteContext);
-  return <Component {...props} />;
-};
+export const Quote: typeof QuoteContextDefault = (props) =>
+  createElement(useContext(QuoteContext), props);

--- a/packages/components/content/source/2-molecules/storytelling/StorytellingComponent.tsx
+++ b/packages/components/content/source/2-molecules/storytelling/StorytellingComponent.tsx
@@ -3,6 +3,7 @@ import {
   FunctionComponent,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn } from '@kickstartds/core/lib/core';
@@ -138,7 +139,5 @@ const StorytellingComponent: FunctionComponent<
 
 export const StorytellingContextDefault = StorytellingComponent;
 export const StorytellingContext = createContext(StorytellingContextDefault);
-export const Storytelling: typeof StorytellingContextDefault = (props) => {
-  const Component = useContext(StorytellingContext);
-  return <Component {...props} />;
-};
+export const Storytelling: typeof StorytellingContextDefault = (props) =>
+  createElement(useContext(StorytellingContext), props);

--- a/packages/components/content/source/2-molecules/visual/VisualComponent.tsx
+++ b/packages/components/content/source/2-molecules/visual/VisualComponent.tsx
@@ -3,6 +3,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { Icon } from '@kickstartds/base/lib/icon';
@@ -57,7 +58,5 @@ const VisualComponent: FunctionComponent<
 
 export const VisualContextDefault = VisualComponent;
 export const VisualContext = createContext(VisualContextDefault);
-export const Visual: typeof VisualContextDefault = (props) => {
-  const Component = useContext(VisualContext);
-  return <Component {...props} />;
-};
+export const Visual: typeof VisualContextDefault = (props) =>
+  createElement(useContext(VisualContext), props);

--- a/packages/components/form/source/1-atoms/form-check/checkbox/CheckboxComponent.tsx
+++ b/packages/components/form/source/1-atoms/form-check/checkbox/CheckboxComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -54,8 +55,5 @@ const CheckboxComponent: ForwardRefRenderFunction<
 export const CheckboxContextDefault = forwardRef(CheckboxComponent);
 export const CheckboxContext = createContext(CheckboxContextDefault);
 export const Checkbox: typeof CheckboxContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(CheckboxContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) => createElement(useContext(CheckboxContext), { ...props, ref })
 );

--- a/packages/components/form/source/1-atoms/form-check/radio/RadioComponent.tsx
+++ b/packages/components/form/source/1-atoms/form-check/radio/RadioComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -53,7 +54,6 @@ export const RadioComponent: ForwardRefRenderFunction<
 
 export const RadioContextDefault = forwardRef(RadioComponent);
 export const RadioContext = createContext(RadioContextDefault);
-export const Radio: typeof RadioContextDefault = forwardRef((props, ref) => {
-  const Component = useContext(RadioContext);
-  return <Component {...props} ref={ref} />;
-});
+export const Radio: typeof RadioContextDefault = forwardRef((props, ref) =>
+  createElement(useContext(RadioContext), { ...props, ref })
+);

--- a/packages/components/form/source/1-atoms/form-field/select-field/SelectFieldComponent.tsx
+++ b/packages/components/form/source/1-atoms/form-field/select-field/SelectFieldComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -78,8 +79,6 @@ const SelectFieldComponent: ForwardRefRenderFunction<
 export const SelectFieldContextDefault = forwardRef(SelectFieldComponent);
 export const SelectFieldContext = createContext(SelectFieldContextDefault);
 export const SelectField: typeof SelectFieldContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(SelectFieldContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) =>
+    createElement(useContext(SelectFieldContext), { ...props, ref })
 );

--- a/packages/components/form/source/1-atoms/form-field/text-area/TextAreaComponent.tsx
+++ b/packages/components/form/source/1-atoms/form-field/text-area/TextAreaComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -69,8 +70,5 @@ const TextAreaComponent: ForwardRefRenderFunction<
 export const TextAreaContextDefault = forwardRef(TextAreaComponent);
 export const TextAreaContext = createContext(TextAreaContextDefault);
 export const TextArea: typeof TextAreaContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(TextAreaContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) => createElement(useContext(TextAreaContext), { ...props, ref })
 );

--- a/packages/components/form/source/1-atoms/form-field/text-field/TextFieldComponent.tsx
+++ b/packages/components/form/source/1-atoms/form-field/text-field/TextFieldComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -68,8 +69,5 @@ const TextFieldComponent: ForwardRefRenderFunction<
 export const TextFieldContextDefault = forwardRef(TextFieldComponent);
 export const TextFieldContext = createContext(TextFieldContextDefault);
 export const TextField: typeof TextFieldContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(TextFieldContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) => createElement(useContext(TextFieldContext), { ...props, ref })
 );

--- a/packages/components/form/source/2-molecules/form-check-group/checkbox-group/CheckboxGroupComponent.tsx
+++ b/packages/components/form/source/2-molecules/form-check-group/checkbox-group/CheckboxGroupComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -50,8 +51,6 @@ const CheckboxGroupComponent: FunctionComponent<
 export const CheckboxGroupContextDefault = CheckboxGroupComponent;
 export const CheckboxGroupContext = createContext(CheckboxGroupContextDefault);
 export const CheckboxGroup: typeof CheckboxGroupContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(CheckboxGroupContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) =>
+    createElement(useContext(CheckboxGroupContext), { ...props, ref })
 );

--- a/packages/components/form/source/2-molecules/form-check-group/radio-group/RadioGroupComponent.tsx
+++ b/packages/components/form/source/2-molecules/form-check-group/radio-group/RadioGroupComponent.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useContext,
   HTMLAttributes,
+  createElement,
 } from 'react';
 import classnames from 'classnames';
 import { renderFn, defaultRenderFn } from '@kickstartds/core/lib/core';
@@ -50,8 +51,6 @@ const RadioGroupComponent: FunctionComponent<
 export const RadioGroupContextDefault = RadioGroupComponent;
 export const RadioGroupContext = createContext(RadioGroupContextDefault);
 export const RadioGroup: typeof RadioGroupContextDefault = forwardRef(
-  (props, ref) => {
-    const Component = useContext(RadioGroupContext);
-    return <Component {...props} ref={ref} />;
-  }
+  (props, ref) =>
+    createElement(useContext(RadioGroupContext), { ...props, ref })
 );


### PR DESCRIPTION
- `Html` (resolves #562)
- `IframeRatio` (resolves #487)
- `TextMedia`
- `Icon`
- `TagLabelContainer`
- `Teaser`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.5.0-canary.567.2754.0
  npm install @kickstartds/blog@1.5.0-canary.567.2754.0
  npm install @kickstartds/content@1.5.0-canary.567.2754.0
  npm install @kickstartds/form@1.5.0-canary.567.2754.0
  # or 
  yarn add @kickstartds/base@1.5.0-canary.567.2754.0
  yarn add @kickstartds/blog@1.5.0-canary.567.2754.0
  yarn add @kickstartds/content@1.5.0-canary.567.2754.0
  yarn add @kickstartds/form@1.5.0-canary.567.2754.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.5.0-next.12`
`@kickstartds/blog@1.5.0-next.12`
`@kickstartds/content@1.5.0-next.12`
`@kickstartds/form@1.5.0-next.12`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - unify login- & logout icons [#524](https://github.com/kickstartDS/kickstartDS/pull/524) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/form`
    - add context structure to more components [#567](https://github.com/kickstartDS/kickstartDS/pull/567) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - don't create argType if schema property has `const` keyword [#560](https://github.com/kickstartDS/kickstartDS/pull/560) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/form`
    - add input types [#498](https://github.com/kickstartDS/kickstartDS/pull/498) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`
    - replace quote date with byline [#471](https://github.com/kickstartDS/kickstartDS/pull/471) ([@lmestel](https://github.com/lmestel))
    - add `expand` prop to count-up component [#470](https://github.com/kickstartDS/kickstartDS/pull/470) ([@lmestel](https://github.com/lmestel))
    - add `enabled` option for count-up link [#445](https://github.com/kickstartDS/kickstartDS/pull/445) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`
    - add render functions to table [#402](https://github.com/kickstartDS/kickstartDS/pull/402) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/base`
    - remove background-image on lightbox arrow buttons [#553](https://github.com/kickstartDS/kickstartDS/pull/553) ([@lmestel](https://github.com/lmestel))
    - accept lightbox links without image [#537](https://github.com/kickstartDS/kickstartDS/pull/537) ([@lmestel](https://github.com/lmestel))
    - add title attribute to slider nav buttons [#456](https://github.com/kickstartDS/kickstartDS/pull/456) ([@lmestel](https://github.com/lmestel))
    - respect button size prop in content-& teaser-box [#437](https://github.com/kickstartDS/kickstartDS/pull/437) ([@lmestel](https://github.com/lmestel))
    - fix table component rerender [#405](https://github.com/kickstartDS/kickstartDS/pull/405) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - add `className` to any schema [#392](https://github.com/kickstartDS/kickstartDS/pull/392) ([@lmestel](https://github.com/lmestel))
  
  #### ⚠️ Pushed to `next`
  
  - build(circleci): add env var to circleci cache hash ([@lmestel](https://github.com/lmestel))
  - Revert "build(deps): bump typescript from 4.4.3 to 4.4.4" ([@lmestel](https://github.com/lmestel))
  
  #### 🏠 Internal
  
  - don't restore yarn cache if `yarn.lock` has changed [#525](https://github.com/kickstartDS/kickstartDS/pull/525) ([@lmestel](https://github.com/lmestel))
  - release fix [#497](https://github.com/kickstartDS/kickstartDS/pull/497) ([@lmestel](https://github.com/lmestel) [@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump tar from 4.4.14 to 4.4.19 [#566](https://github.com/kickstartDS/kickstartDS/pull/566) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump tmpl from 1.0.4 to 1.0.5 [#565](https://github.com/kickstartDS/kickstartDS/pull/565) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.9 to 5.0.10 [#564](https://github.com/kickstartDS/kickstartDS/pull/564) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump svgstore from 3.0.0-2 to 3.0.1 [#557](https://github.com/kickstartDS/kickstartDS/pull/557) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.8 to 5.0.9 [#554](https://github.com/kickstartDS/kickstartDS/pull/554) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 13.2.1 to 14.1.0 [#552](https://github.com/kickstartDS/kickstartDS/pull/552) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump vite from 2.6.12 to 2.6.13 [#539](https://github.com/kickstartDS/kickstartDS/pull/539) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.58.3 to 2.59.0 [#548](https://github.com/kickstartDS/kickstartDS/pull/548) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.0.4 to 6.0.5 [#538](https://github.com/kickstartDS/kickstartDS/pull/538) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.3.7 to 10.4.0 [#541](https://github.com/kickstartDS/kickstartDS/pull/541) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.2.4 to 11.2.6 [#535](https://github.com/kickstartDS/kickstartDS/pull/535) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.11 to 2.6.12 [#536](https://github.com/kickstartDS/kickstartDS/pull/536) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump auto from 10.32.1 to 10.32.2 [#530](https://github.com/kickstartDS/kickstartDS/pull/530) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.58.1 to 2.58.3 [#527](https://github.com/kickstartDS/kickstartDS/pull/527) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.10 to 2.6.11 [#523](https://github.com/kickstartDS/kickstartDS/pull/523) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump husky from 7.0.2 to 7.0.4 [#518](https://github.com/kickstartDS/kickstartDS/pull/518) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump postcss from 8.3.9 to 8.3.11 [#520](https://github.com/kickstartDS/kickstartDS/pull/520) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @types/react-dom from 17.0.9 to 17.0.10 [#522](https://github.com/kickstartDS/kickstartDS/pull/522) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.2.3 to 11.2.4 [#516](https://github.com/kickstartDS/kickstartDS/pull/516) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.58.0 to 2.58.1 [#517](https://github.com/kickstartDS/kickstartDS/pull/517) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.11 to 6.3.12 [#504](https://github.com/kickstartDS/kickstartDS/pull/504) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.0.2 to 6.0.4 [#499](https://github.com/kickstartDS/kickstartDS/pull/499) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump typescript from 4.4.3 to 4.4.4 [#494](https://github.com/kickstartDS/kickstartDS/pull/494) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 13.2.0 to 13.2.1 [#482](https://github.com/kickstartDS/kickstartDS/pull/482) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.5 to 2.6.7 [#486](https://github.com/kickstartDS/kickstartDS/pull/486) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.10 to 6.3.11 [#495](https://github.com/kickstartDS/kickstartDS/pull/495) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump chromatic from 5.10.2 to 6.0.2 [#491](https://github.com/kickstartDS/kickstartDS/pull/491) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.3 to 2.6.5 [#480](https://github.com/kickstartDS/kickstartDS/pull/480) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.3.8 to 6.3.10 [#478](https://github.com/kickstartDS/kickstartDS/pull/478) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump lint-staged from 11.2.0 to 11.2.3 [#483](https://github.com/kickstartDS/kickstartDS/pull/483) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/core from 7.15.5 to 7.15.8 [#474](https://github.com/kickstartDS/kickstartDS/pull/474) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.2 to 2.6.3 [#469](https://github.com/kickstartDS/kickstartDS/pull/469) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump lint-staged from 11.1.2 to 11.2.0 [#465](https://github.com/kickstartDS/kickstartDS/pull/465) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.8 to 8.3.9 [#466](https://github.com/kickstartDS/kickstartDS/pull/466) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.57.0 to 2.58.0 [#455](https://github.com/kickstartDS/kickstartDS/pull/455) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @kickstartds/storybook-addon-component-tokens from 0.1.4 to 0.1.5 [#450](https://github.com/kickstartDS/kickstartDS/pull/450) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 5.10.1 to 5.10.2 [#453](https://github.com/kickstartDS/kickstartDS/pull/453) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump auto from 10.32.0 to 10.32.1 [#452](https://github.com/kickstartDS/kickstartDS/pull/452) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.7 to 8.3.8 [#436](https://github.com/kickstartDS/kickstartDS/pull/436) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump rollup-plugin-ts from 1.4.6 to 1.4.7 [#433](https://github.com/kickstartDS/kickstartDS/pull/433) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 13.1.0 to 13.2.0 [#439](https://github.com/kickstartDS/kickstartDS/pull/439) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.5.8 to 2.5.10 [#418](https://github.com/kickstartDS/kickstartDS/pull/418) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.3.4 to 10.3.5 [#425](https://github.com/kickstartDS/kickstartDS/pull/425) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.6 to 8.3.7 [#426](https://github.com/kickstartDS/kickstartDS/pull/426) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.56.3 to 2.57.0 [#424](https://github.com/kickstartDS/kickstartDS/pull/424) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-ts from 1.4.2 to 1.4.6 [#423](https://github.com/kickstartDS/kickstartDS/pull/423) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 5.10.0 to 5.10.1 [#422](https://github.com/kickstartDS/kickstartDS/pull/422) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 5.9.2 to 5.10.0 [#417](https://github.com/kickstartDS/kickstartDS/pull/417) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.5.6 to 2.5.8 [#415](https://github.com/kickstartDS/kickstartDS/pull/415) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss-sort-media-queries from 3.11.12 to 4.1.0 [#397](https://github.com/kickstartDS/kickstartDS/pull/397) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump prettier from 2.4.0 to 2.4.1 [#412](https://github.com/kickstartDS/kickstartDS/pull/412) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-ts from 1.4.1 to 1.4.2 [#414](https://github.com/kickstartDS/kickstartDS/pull/414) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump auto from 10.31.0 to 10.32.0 [#406](https://github.com/kickstartDS/kickstartDS/pull/406) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @whitespace/storybook-addon-html from v5.2.0 to v5.3.0 [#409](https://github.com/kickstartDS/kickstartDS/pull/409) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump typescript from 4.4.2 to 4.4.3 [#394](https://github.com/kickstartDS/kickstartDS/pull/394) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump json-schema-to-typescript from 10.1.4 to 10.1.5 [#396](https://github.com/kickstartDS/kickstartDS/pull/396) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.15.4 to 7.15.6 [#390](https://github.com/kickstartDS/kickstartDS/pull/390) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump prettier from 2.3.2 to 2.4.0 [#391](https://github.com/kickstartDS/kickstartDS/pull/391) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps-dev): bump @types/react from 17.0.33 to 17.0.34 [#558](https://github.com/kickstartDS/kickstartDS/pull/558) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.32 to 17.0.33 [#526](https://github.com/kickstartDS/kickstartDS/pull/526) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump react-markdown from 7.0.1 to 7.1.0 [#519](https://github.com/kickstartDS/kickstartDS/pull/519) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.29 to 17.0.32 [#515](https://github.com/kickstartDS/kickstartDS/pull/515) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.27 to 17.0.29 [#496](https://github.com/kickstartDS/kickstartDS/pull/496) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.26 to 17.0.27 [#461](https://github.com/kickstartDS/kickstartDS/pull/461) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.25 to 17.0.26 [#454](https://github.com/kickstartDS/kickstartDS/pull/454) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.24 to 17.0.25 [#444](https://github.com/kickstartDS/kickstartDS/pull/444) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump simplebar from 5.3.5 to 5.3.6 [#430](https://github.com/kickstartDS/kickstartDS/pull/430) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.22 to 17.0.24 [#421](https://github.com/kickstartDS/kickstartDS/pull/421) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.21 to 17.0.22 [#419](https://github.com/kickstartDS/kickstartDS/pull/419) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.20 to 17.0.21 [#404](https://github.com/kickstartDS/kickstartDS/pull/404) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/core from 7.15.8 to 7.16.0 [#545](https://github.com/kickstartDS/kickstartDS/pull/545) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - build(deps-dev): bump storybook-design-token from 1.2.3 to 1.3.0 [#540](https://github.com/kickstartDS/kickstartDS/pull/540) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.9 to 0.13.12 [#547](https://github.com/kickstartDS/kickstartDS/pull/547) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.43.3 to 1.43.4 [#534](https://github.com/kickstartDS/kickstartDS/pull/534) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.5 to 0.13.9 [#514](https://github.com/kickstartDS/kickstartDS/pull/514) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.43.2 to 1.43.3 [#521](https://github.com/kickstartDS/kickstartDS/pull/521) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.42.1 to 1.43.2 [#500](https://github.com/kickstartDS/kickstartDS/pull/500) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.4 to 0.13.5 [#488](https://github.com/kickstartDS/kickstartDS/pull/488) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.3 to 0.13.4 [#467](https://github.com/kickstartDS/kickstartDS/pull/467) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @storybook/core from 6.3.8 to 6.3.9 [#458](https://github.com/kickstartDS/kickstartDS/pull/458) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps): bump esbuild from 0.13.2 to 0.13.3 [#441](https://github.com/kickstartDS/kickstartDS/pull/441) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump storybook-design-token from 1.2.0 to 1.2.2 [#435](https://github.com/kickstartDS/kickstartDS/pull/435) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.1 to 0.13.2 [#429](https://github.com/kickstartDS/kickstartDS/pull/429) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.42.0 to 1.42.1 [#428](https://github.com/kickstartDS/kickstartDS/pull/428) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.28 to 0.13.1 [#427](https://github.com/kickstartDS/kickstartDS/pull/427) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.41.1 to 1.42.0 [#420](https://github.com/kickstartDS/kickstartDS/pull/420) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.41.0 to 1.41.1 [#413](https://github.com/kickstartDS/kickstartDS/pull/413) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.40.0 to 1.41.0 [#403](https://github.com/kickstartDS/kickstartDS/pull/403) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.39.2 to 1.40.0 [#400](https://github.com/kickstartDS/kickstartDS/pull/400) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.27 to 0.12.28 [#399](https://github.com/kickstartDS/kickstartDS/pull/399) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.26 to 0.12.27 [#395](https://github.com/kickstartDS/kickstartDS/pull/395) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.12.25 to 0.12.26 [#389](https://github.com/kickstartDS/kickstartDS/pull/389) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.39.0 to 1.39.2 [#388](https://github.com/kickstartDS/kickstartDS/pull/388) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`
    - build(deps): bump date-fns from 2.24.0 to 2.25.0 [#468](https://github.com/kickstartDS/kickstartDS/pull/468) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`
    - build(deps): bump date-fns from 2.23.0 to 2.24.0 [#416](https://github.com/kickstartDS/kickstartDS/pull/416) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
