### PR TITLE
Port icon fix to `master`

### DIFF
--- a/packages/components/base/source/1-atoms/button/link-button/link-button.schema.json
+++ b/packages/components/base/source/1-atoms/button/link-button/link-button.schema.json
@@ -33,7 +33,7 @@
       "$ref": "http://frontend.ruhmesmeile.com/base/atoms/button.schema.json#/definitions/className"
     },
     "icon": {
-      "$ref": "http://frontend.ruhmesmeile.com/base/atoms/button.schema.json#/definitions/icon"
+      "$ref": "http://frontend.ruhmesmeile.com/base/atoms/icon.definitions.json"
     },
     "iconBefore": {
       "$ref": "http://frontend.ruhmesmeile.com/base/atoms/button.schema.json#/definitions/iconBefore"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.5.1-next.0`
`@kickstartds/blog@1.5.1-next.0`
`@kickstartds/content@1.5.1-next.0`
`@kickstartds/form@1.5.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@kickstartds/base`
    - fix(icon): chained ref for link-button -> button -> icon [#573](https://github.com/kickstartDS/kickstartDS/pull/573) ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
