### PR TITLE
fix object & array handling in unpack helper

### DIFF
--- a/packages/components/core/source/storybook/helpers.js
+++ b/packages/components/core/source/storybook/helpers.js
@@ -141,9 +141,10 @@ const unpack = (flatArgs) => {
   // eslint-disable-next-line no-restricted-syntax
   for (const [key, value] of Object.entries(flatArgs)) {
     key.split('.').reduce((prev, curr, i, arr) => {
-      prev[curr] =
-        prev[curr] ||
-        (arr[i + 1] != null ? (Number.isNaN(arr[i + 1]) ? {} : []) : value);
+      if (prev[curr] == null) {
+        const next = arr[i + 1];
+        prev[curr] = next != null ? (Number.isNaN(+next) ? {} : []) : value;
+      }
       return prev[curr];
     }, args);
   }


### PR DESCRIPTION
> The Number.isNaN() method determines whether the passed value is NaN **and** its type is Number. ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN))

So instead of `Number.isNaN(string)` we have to cast the value first: `Number.isNaN(+string)`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.5.2-canary.584.2834.0
  npm install @kickstartds/blog@1.5.2-canary.584.2834.0
  npm install @kickstartds/content@1.5.2-canary.584.2834.0
  npm install @kickstartds/core@1.5.1-canary.584.2834.0
  npm install @kickstartds/form@1.5.2-canary.584.2834.0
  # or 
  yarn add @kickstartds/base@1.5.2-canary.584.2834.0
  yarn add @kickstartds/blog@1.5.2-canary.584.2834.0
  yarn add @kickstartds/content@1.5.2-canary.584.2834.0
  yarn add @kickstartds/core@1.5.1-canary.584.2834.0
  yarn add @kickstartds/form@1.5.2-canary.584.2834.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.5.2-next.0`
`@kickstartds/blog@1.5.2-next.0`
`@kickstartds/content@1.5.2-next.0`
`@kickstartds/core@1.5.1-next.0`
`@kickstartds/form@1.5.2-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@kickstartds/core`
    - fix object & array handling in unpack helper [#584](https://github.com/kickstartDS/kickstartDS/pull/584) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump rollup from 2.59.0 to 2.60.0 [#582](https://github.com/kickstartDS/kickstartDS/pull/582) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.13 to 2.6.14 [#578](https://github.com/kickstartDS/kickstartDS/pull/578) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.0.5 to 6.0.6 [#580](https://github.com/kickstartDS/kickstartDS/pull/580) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/runtime from 7.16.0 to 7.16.3 [#577](https://github.com/kickstartDS/kickstartDS/pull/577) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump pubsub-js from 1.9.3 to 1.9.4 [#581](https://github.com/kickstartDS/kickstartDS/pull/581) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.12 to 0.13.13 [#576](https://github.com/kickstartDS/kickstartDS/pull/576) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
