### PR TITLE
fix visual video playback

### DIFF
--- a/packages/components/content/source/2-molecules/visual/Visual.js
+++ b/packages/components/content/source/2-molecules/visual/Visual.js
@@ -1,5 +1,4 @@
 import { Component, define } from '@kickstartds/core/lib/core';
-import { windowEvents } from '@kickstartds/core/lib/utils';
 import 'objectFitPolyfill/dist/objectFitPolyfill.basic.min';
 
 const identifier = 'visual';
@@ -24,40 +23,31 @@ export default class Visual extends Component {
       this.continueBtn.addEventListener('click', this);
     }
 
-    this.video = element.querySelector('.c-visual__video');
-    if (this.video) {
-      // prevent multiple scroll listeners
-      if (!this.scrollToken) {
-        this.scrollToken = window.rm.radio.on(windowEvents.scroll, () =>
-          this.playVideo()
-        );
-      }
-      this.videoIsPlaying = false;
-      this.playVideo();
+    const video = element.querySelector('.c-visual__video');
+    if (video) {
+      let inViewport;
+      let videoIsPlaying;
+      const playVideo = () => {
+        if (inViewport) {
+          if (!videoIsPlaying) {
+            video.play();
+          }
+        } else if (videoIsPlaying) {
+          video.pause();
+        }
+        videoIsPlaying = inViewport;
+      };
+      const observer = new IntersectionObserver((entries) => {
+        inViewport = entries.reduce((_, entry) => entry.isIntersecting, false);
+        playVideo();
+      });
+      observer.observe(element);
+      playVideo();
     }
   }
 
   onclick() {
     scrollToSibling(this.element);
-  }
-
-  playVideo() {
-    if (this.isScrolledOutOfView) {
-      if (this.videoIsPlaying) {
-        this.video.pause();
-        this.videoIsPlaying = false;
-      }
-    } else if (!this.videoIsPlaying) {
-      this.video.play();
-      this.videoIsPlaying = true;
-    }
-  }
-
-  get isScrolledOutOfView() {
-    const docViewTop = window.pageYOffset;
-    const elemBottom = this.element.offsetHeight;
-
-    return docViewTop > elemBottom;
   }
 }
 


### PR DESCRIPTION
resolves #759
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.5.2-canary.760.3335.0
  npm install @kickstartds/blog@1.5.2-canary.760.3335.0
  npm install @kickstartds/content@1.5.2-canary.760.3335.0
  npm install @kickstartds/core@1.5.1-canary.760.3335.0
  npm install @kickstartds/form@1.5.2-canary.760.3335.0
  # or 
  yarn add @kickstartds/base@1.5.2-canary.760.3335.0
  yarn add @kickstartds/blog@1.5.2-canary.760.3335.0
  yarn add @kickstartds/content@1.5.2-canary.760.3335.0
  yarn add @kickstartds/core@1.5.1-canary.760.3335.0
  yarn add @kickstartds/form@1.5.2-canary.760.3335.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@1.6.0-next.4`
`@kickstartds/blog@1.6.0-next.4`
`@kickstartds/content@1.6.0-next.4`
`@kickstartds/core@1.6.0-next.4`
`@kickstartds/form@1.6.0-next.4`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - `@kickstartds/base`, `@kickstartds/core`
    - add container queries polyfill [#571](https://github.com/kickstartDS/kickstartDS/pull/571) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - every component forwards its `ref` [#645](https://github.com/kickstartDS/kickstartDS/pull/645) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - add `createProvider` helper [#605](https://github.com/kickstartDS/kickstartDS/pull/605) ([@lmestel](https://github.com/lmestel))
  
  #### 🐛 Bug Fix
  
  - `@kickstartds/content`
    - fix visual video playback [#760](https://github.com/kickstartDS/kickstartDS/pull/760) ([@lmestel](https://github.com/lmestel))
    - fix visual continue button [#724](https://github.com/kickstartDS/kickstartDS/pull/724) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/core`
    - fix object & array handling in unpack helper [#584](https://github.com/kickstartDS/kickstartDS/pull/584) ([@lmestel](https://github.com/lmestel))
  
  #### 🏠 Internal
  
  - select stories for storybook build [#681](https://github.com/kickstartDS/kickstartDS/pull/681) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - update stylelint [#653](https://github.com/kickstartDS/kickstartDS/pull/653) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump @babel/preset-env from 7.16.7 to 7.16.8 [#740](https://github.com/kickstartDS/kickstartDS/pull/740) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.4.12 to 6.4.13 [#752](https://github.com/kickstartDS/kickstartDS/pull/752) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.63.0 to 2.64.0 [#756](https://github.com/kickstartDS/kickstartDS/pull/756) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump shelljs from 0.8.4 to 0.8.5 [#750](https://github.com/kickstartDS/kickstartDS/pull/750) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump nth-check from 2.0.0 to 2.0.1 [#749](https://github.com/kickstartDS/kickstartDS/pull/749) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-styles from 3.14.1 to 4.0.0 [#748](https://github.com/kickstartDS/kickstartDS/pull/748) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.4.10 to 6.4.12 [#742](https://github.com/kickstartDS/kickstartDS/pull/742) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 16.0.1 to 16.0.2 [#735](https://github.com/kickstartDS/kickstartDS/pull/735) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.3.3 to 6.3.4 [#738](https://github.com/kickstartDS/kickstartDS/pull/738) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.4.1 to 10.4.2 [#736](https://github.com/kickstartDS/kickstartDS/pull/736) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss-scss from 4.0.2 to 4.0.3 [#733](https://github.com/kickstartDS/kickstartDS/pull/733) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.14 to 5.0.15 [#725](https://github.com/kickstartDS/kickstartDS/pull/725) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @storybook/core from 6.4.9 to 6.4.10 [#727](https://github.com/kickstartDS/kickstartDS/pull/727) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps-dev): bump lint-staged from 12.1.5 to 12.1.7 [#726](https://github.com/kickstartDS/kickstartDS/pull/726) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.61.1 to 2.63.0 [#721](https://github.com/kickstartDS/kickstartDS/pull/721) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 12.1.3 to 12.1.5 [#716](https://github.com/kickstartDS/kickstartDS/pull/716) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump autoprefixer from 10.4.0 to 10.4.1 [#720](https://github.com/kickstartDS/kickstartDS/pull/720) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.12 to 5.0.14 [#699](https://github.com/kickstartDS/kickstartDS/pull/699) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump stylelint from 14.1.0 to 14.2.0 [#701](https://github.com/kickstartDS/kickstartDS/pull/701) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 15.0.0 to 16.0.1 [#708](https://github.com/kickstartDS/kickstartDS/pull/708) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.2.3 to 6.3.3 [#703](https://github.com/kickstartDS/kickstartDS/pull/703) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.2.1 to 6.2.3 [#696](https://github.com/kickstartDS/kickstartDS/pull/696) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 12.1.2 to 12.1.3 [#695](https://github.com/kickstartDS/kickstartDS/pull/695) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-node-externals from 3.1.1 to 3.1.2 [#692](https://github.com/kickstartDS/kickstartDS/pull/692) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.2.0 to 6.2.1 [#694](https://github.com/kickstartDS/kickstartDS/pull/694) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.4.4 to 8.4.5 [#688](https://github.com/kickstartDS/kickstartDS/pull/688) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-node-externals from 2.2.0 to 3.1.1 [#682](https://github.com/kickstartDS/kickstartDS/pull/682) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump auto from 10.32.3 to 10.32.5 [#673](https://github.com/kickstartDS/kickstartDS/pull/673) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  - build(deps): bump @babel/preset-typescript from 7.16.0 to 7.16.5 [#672](https://github.com/kickstartDS/kickstartDS/pull/672) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.60.1 to 2.61.1 [#674](https://github.com/kickstartDS/kickstartDS/pull/674) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump prettier from 2.5.0 to 2.5.1 [#671](https://github.com/kickstartDS/kickstartDS/pull/671) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.0.6 to 6.2.0 [#675](https://github.com/kickstartDS/kickstartDS/pull/675) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump typescript from 4.5.2 to 4.5.3 [#669](https://github.com/kickstartDS/kickstartDS/pull/669) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss-sort-media-queries from 4.1.0 to 4.2.1 [#625](https://github.com/kickstartDS/kickstartDS/pull/625) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.11 to 5.0.12 [#623](https://github.com/kickstartDS/kickstartDS/pull/623) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump debug from 4.3.2 to 4.3.3 [#629](https://github.com/kickstartDS/kickstartDS/pull/629) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump auto from 10.32.2 to 10.32.3 [#617](https://github.com/kickstartDS/kickstartDS/pull/617) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/cli from 14.1.0 to 15.0.0 [#618](https://github.com/kickstartDS/kickstartDS/pull/618) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump postcss from 8.3.11 to 8.4.1 [#609](https://github.com/kickstartDS/kickstartDS/pull/609) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump @commitlint/config-conventional from 14.1.0 to 15.0.0 [#594](https://github.com/kickstartDS/kickstartDS/pull/594) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump typescript from 4.4.4 to 4.5.2 [#593](https://github.com/kickstartDS/kickstartDS/pull/593) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump lint-staged from 11.2.6 to 12.1.2 [#604](https://github.com/kickstartDS/kickstartDS/pull/604) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup-plugin-ts from 1.4.7 to 2.0.4 [#602](https://github.com/kickstartDS/kickstartDS/pull/602) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.60.0 to 2.60.1 [#610](https://github.com/kickstartDS/kickstartDS/pull/610) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @babel/preset-env from 7.16.0 to 7.16.4 [#591](https://github.com/kickstartDS/kickstartDS/pull/591) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump cssnano from 5.0.10 to 5.0.11 [#589](https://github.com/kickstartDS/kickstartDS/pull/589) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump yargs-parser from 20.2.9 to 21.0.0 [#586](https://github.com/kickstartDS/kickstartDS/pull/586) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump rollup from 2.59.0 to 2.60.0 [#582](https://github.com/kickstartDS/kickstartDS/pull/582) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump vite from 2.6.13 to 2.6.14 [#578](https://github.com/kickstartDS/kickstartDS/pull/578) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps-dev): bump chromatic from 6.0.5 to 6.0.6 [#580](https://github.com/kickstartDS/kickstartDS/pull/580) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`
    - build(deps): bump react-markdown from 7.1.2 to 8.0.0 [#758](https://github.com/kickstartDS/kickstartDS/pull/758) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump react-markdown from 7.1.1 to 7.1.2 [#713](https://github.com/kickstartDS/kickstartDS/pull/713) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.37 to 17.0.38 [#705](https://github.com/kickstartDS/kickstartDS/pull/705) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump @glidejs/glide from `e71f8bf` to `3675127` [#624](https://github.com/kickstartDS/kickstartDS/pull/624) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps): bump react-markdown from 7.1.0 to 7.1.1 [#678](https://github.com/kickstartDS/kickstartDS/pull/678) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @storybook/cli from 6.3.12 to 6.4.9 [#663](https://github.com/kickstartDS/kickstartDS/pull/663) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps-dev): bump @types/react from 17.0.35 to 17.0.37 [#614](https://github.com/kickstartDS/kickstartDS/pull/614) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps-dev): bump @types/react from 17.0.34 to 17.0.35 [#585](https://github.com/kickstartDS/kickstartDS/pull/585) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/core`
    - build(deps): bump fast-glob from 3.2.10 to 3.2.11 [#751](https://github.com/kickstartDS/kickstartDS/pull/751) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.47.0 to 1.48.0 [#747](https://github.com/kickstartDS/kickstartDS/pull/747) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.46.0 to 1.47.0 [#739](https://github.com/kickstartDS/kickstartDS/pull/739) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.14.10 to 0.14.11 [#737](https://github.com/kickstartDS/kickstartDS/pull/737) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump fast-glob from 3.2.7 to 3.2.10 [#732](https://github.com/kickstartDS/kickstartDS/pull/732) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.45.0 to 1.46.0 [#712](https://github.com/kickstartDS/kickstartDS/pull/712) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.14.3 to 0.14.10 [#711](https://github.com/kickstartDS/kickstartDS/pull/711) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.43.5 to 1.45.0 [#683](https://github.com/kickstartDS/kickstartDS/pull/683) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps): bump esbuild from 0.13.15 to 0.14.3 [#667](https://github.com/kickstartDS/kickstartDS/pull/667) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump sass from 1.43.4 to 1.43.5 [#616](https://github.com/kickstartDS/kickstartDS/pull/616) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.13 to 0.13.15 [#601](https://github.com/kickstartDS/kickstartDS/pull/601) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump pubsub-js from 1.9.3 to 1.9.4 [#581](https://github.com/kickstartDS/kickstartDS/pull/581) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump esbuild from 0.13.12 to 0.13.13 [#576](https://github.com/kickstartDS/kickstartDS/pull/576) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/content`, `@kickstartds/core`, `@kickstartds/form`
    - build(deps): bump @babel/core from 7.16.5 to 7.16.7 [#719](https://github.com/kickstartDS/kickstartDS/pull/719) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump @babel/core from 7.16.0 to 7.16.5 [#689](https://github.com/kickstartDS/kickstartDS/pull/689) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps): bump @babel/runtime from 7.16.0 to 7.16.3 [#577](https://github.com/kickstartDS/kickstartDS/pull/577) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`
    - build(deps): bump date-fns from 2.27.0 to 2.28.0 [#723](https://github.com/kickstartDS/kickstartDS/pull/723) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump date-fns from 2.26.0 to 2.27.0 [#668](https://github.com/kickstartDS/kickstartDS/pull/668) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump date-fns from 2.25.0 to 2.26.0 [#613](https://github.com/kickstartDS/kickstartDS/pull/613) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/core`
    - build(deps-dev): bump prettier from 2.4.1 to 2.5.0 [#615](https://github.com/kickstartDS/kickstartDS/pull/615) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  
  #### Authors: 2
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
