### PR TITLE
align buttons in content- & teaser-box to the bottom

### DIFF
--- a/packages/components/base/source/2-molecules/content-box/content-box.scss
+++ b/packages/components/base/source/2-molecules/content-box/content-box.scss
@@ -9,6 +9,8 @@ $vars: meta.module-variables(content-box-vars);
   margin-bottom: 2em;
   box-sizing: border-box;
   contain: layout inline-size style;
+  display: flex;
+  flex-direction: column;
 
   &--align-center {
     text-align: center;

--- a/packages/components/base/source/2-molecules/teaser-box/teaser-box.scss
+++ b/packages/components/base/source/2-molecules/teaser-box/teaser-box.scss
@@ -1,5 +1,7 @@
 .c-teaser-box {
   contain: layout inline-size style;
+  display: flex;
+  flex-direction: column;
 
   .c-teaser__image {
     flex-grow: 0;


### PR DESCRIPTION
so the buttons are on one line if boxes are placed side by side
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.6.0-canary.931.3985.0
  npm install @kickstartds/blog@1.6.0-canary.931.3985.0
  npm install @kickstartds/content@1.6.0-canary.931.3985.0
  npm install @kickstartds/core@1.6.0-canary.931.3985.0
  npm install @kickstartds/form@1.6.0-canary.931.3985.0
  # or 
  yarn add @kickstartds/base@1.6.0-canary.931.3985.0
  yarn add @kickstartds/blog@1.6.0-canary.931.3985.0
  yarn add @kickstartds/content@1.6.0-canary.931.3985.0
  yarn add @kickstartds/core@1.6.0-canary.931.3985.0
  yarn add @kickstartds/form@1.6.0-canary.931.3985.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
