### PR TITLE
make image optional in storytelling

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
+++ b/packages/components/base/source/0-base/3-objects/section/SectionProps.ts
@@ -1798,7 +1798,7 @@ export interface Storytelling {
   backgroundImage?: BackgroundImage2;
   backgroundColor?: BackgroundColor;
   full?: FullSizeImage;
-  image: Image;
+  image?: Image;
   box: TextBox2;
   className?: Class5;
   [k: string]: unknown;

--- a/packages/components/content/source/2-molecules/storytelling/StorytellingComponent.tsx
+++ b/packages/components/content/source/2-molecules/storytelling/StorytellingComponent.tsx
@@ -43,16 +43,18 @@ const StorytellingMixin: FunctionComponent<
   <div
     className={classnames(
       'c-storytelling',
-      {
+      image && {
         'c-storytelling--order-mobile-image-last':
           image.order && image.order.mobileImageLast,
         'c-storytelling--order-desktop-image-last':
           image.order && image.order.desktopImageLast,
-        'c-storytelling--full': full,
         'c-storytelling--four-to-three': image.ratio === '4:3',
         'c-storytelling--three-to-two': image.ratio === '3:2',
         'c-storytelling--sixteen-to-nine': image.ratio === '16:9',
         'c-storytelling--square': image.ratio === '1:1',
+      },
+      {
+        'c-storytelling--full': full,
         lazyload: lazy && backgroundImage,
       },
       className
@@ -64,19 +66,21 @@ const StorytellingMixin: FunctionComponent<
     data-bg={(lazy && backgroundImage) || null}
     {...props}
   >
-    <div
-      className={classnames(
-        'c-storytelling__image',
-        image.vAlign &&
-          image.vAlign !== 'center' &&
-          `c-storytelling__image--${image.vAlign}`,
-        image.hAlign &&
-          image.hAlign !== 'center' &&
-          `c-storytelling__image--${image.hAlign}`
-      )}
-    >
-      {image.source && <Picture src={image.source} alt="" lazy={lazy} />}
-    </div>
+    {image?.source && (
+      <div
+        className={classnames(
+          'c-storytelling__image',
+          image.vAlign &&
+            image.vAlign !== 'center' &&
+            `c-storytelling__image--${image.vAlign}`,
+          image.hAlign &&
+            image.hAlign !== 'center' &&
+            `c-storytelling__image--${image.hAlign}`
+        )}
+      >
+        <Picture src={image.source} alt="" lazy={lazy} />
+      </div>
+    )}
 
     <div
       className={classnames(

--- a/packages/components/content/source/2-molecules/storytelling/StorytellingProps.ts
+++ b/packages/components/content/source/2-molecules/storytelling/StorytellingProps.ts
@@ -168,7 +168,7 @@ export interface StorytellingProps {
   backgroundImage?: BackgroundImage;
   backgroundColor?: BackgroundColor;
   full?: FullSizeImage;
-  image: Image;
+  image?: Image;
   box: TextBox;
   className?: Class;
   [k: string]: unknown;

--- a/packages/components/content/source/2-molecules/storytelling/storytelling.schema.json
+++ b/packages/components/content/source/2-molecules/storytelling/storytelling.schema.json
@@ -151,5 +151,5 @@
       "type": "string"
     }
   },
-  "required": ["image", "box"]
+  "required": ["box"]
 }

--- a/packages/components/content/source/2-molecules/storytelling/storytelling.scss
+++ b/packages/components/content/source/2-molecules/storytelling/storytelling.scss
@@ -198,6 +198,10 @@ $vars: meta.module-variables(storytelling-vars);
     justify-content: center;
     align-items: center;
 
+    &:only-child {
+      --c-storytelling--horizontal-padding: 0;
+    }
+
     @include breakpoint.media('≥s') {
       padding-left: var(--c-storytelling--horizontal-padding);
     }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@1.6.0-canary.932.3988.0
  npm install @kickstartds/blog@1.6.0-canary.932.3988.0
  npm install @kickstartds/content@1.6.0-canary.932.3988.0
  npm install @kickstartds/core@1.6.0-canary.932.3988.0
  npm install @kickstartds/form@1.6.0-canary.932.3988.0
  # or 
  yarn add @kickstartds/base@1.6.0-canary.932.3988.0
  yarn add @kickstartds/blog@1.6.0-canary.932.3988.0
  yarn add @kickstartds/content@1.6.0-canary.932.3988.0
  yarn add @kickstartds/core@1.6.0-canary.932.3988.0
  yarn add @kickstartds/form@1.6.0-canary.932.3988.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
