### PR TITLE
fix(container): improve container mixin

### DIFF
--- a/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
+++ b/packages/components/base/source/0-base/3-objects/section/SectionComponent.tsx
@@ -3,16 +3,15 @@ import {
   ForwardRefRenderFunction,
   HTMLAttributes,
   forwardRef,
-  createElement,
   createContext,
-  useContext,
 } from 'react';
+import { withContainer } from '@kickstartds/core/lib/container';
 import classnames from 'classnames';
 import { Headline } from '../../../2-molecules/headline/HeadlineComponent';
 import { SectionProps } from './SectionProps';
 import './section.scss';
 
-const Container: FunctionComponent<SectionProps> = ({
+const SectionContainer: FunctionComponent<SectionProps> = ({
   width,
   gutter,
   mode,
@@ -66,20 +65,18 @@ const SectionComponent: ForwardRefRenderFunction<
     {...props}
   >
     {headline && headline.content && (
-      <Container width={width}>
+      <SectionContainer width={width}>
         <Headline {...headline} />
-      </Container>
+      </SectionContainer>
     )}
     {children && (
-      <Container width={width} gutter={gutter} mode={mode}>
+      <SectionContainer width={width} gutter={gutter} mode={mode}>
         {children}
-      </Container>
+      </SectionContainer>
     )}
   </div>
 );
 
 export const SectionContextDefault = forwardRef(SectionComponent);
 export const SectionContext = createContext(SectionContextDefault);
-export const Section: typeof SectionContextDefault = forwardRef((props, ref) =>
-  createElement(useContext(SectionContext), { ...props, ref })
-);
+export const Section = withContainer('section', SectionContext);

--- a/packages/components/base/source/1-atoms/table/table.scss
+++ b/packages/components/base/source/1-atoms/table/table.scss
@@ -63,7 +63,7 @@ $vars: meta.module-variables(table-vars);
   }
 
   &--responsive {
-    @include container.size('<' 450px) {
+    @include container.size('<', 450px) {
       thead {
         display: none;
       }

--- a/packages/components/base/source/2-molecules/headline/headline.scss
+++ b/packages/components/base/source/2-molecules/headline/headline.scss
@@ -25,7 +25,7 @@ $vars: meta.module-variables(headline-vars);
     margin-top: calc(var(--c-headline--margin-bottom) * 1.5);
   }
 
-  @include container.size('≥' 640px) {
+  @include container.size('≥', 640px) {
     max-width: 70%;
   }
 

--- a/packages/components/base/source/2-molecules/slider/slider-arrows/_slider-arrows.scss
+++ b/packages/components/base/source/2-molecules/slider/slider-arrows/_slider-arrows.scss
@@ -6,7 +6,7 @@
   opacity: 0;
   transition: 0.3s;
 
-  @include container.size('≥' 960px) {
+  @include container.size('≥', 960px) {
     display: block;
   }
 

--- a/packages/components/base/source/2-molecules/teaser-box/TeaserBoxComponent.tsx
+++ b/packages/components/base/source/2-molecules/teaser-box/TeaserBoxComponent.tsx
@@ -2,10 +2,9 @@ import {
   ForwardRefRenderFunction,
   HTMLAttributes,
   forwardRef,
-  createElement,
   createContext,
-  useContext,
 } from 'react';
+import { withContainer } from '@kickstartds/core/lib/container';
 import classnames from 'classnames';
 import { Picture } from '../../1-atoms/image/picture';
 import { TeaserBoxProps } from './TeaserBoxProps';
@@ -42,6 +41,4 @@ const TeaserBoxComponent: ForwardRefRenderFunction<
 
 export const TeaserBoxContextDefault = forwardRef(TeaserBoxComponent);
 export const TeaserBoxContext = createContext(TeaserBoxContextDefault);
-export const TeaserBox: typeof TeaserBoxContextDefault = forwardRef(
-  (props, ref) => createElement(useContext(TeaserBoxContext), { ...props, ref })
-);
+export const TeaserBox = withContainer('teaser-box', TeaserBoxContext);

--- a/packages/components/base/source/2-molecules/text-media/text-media.scss
+++ b/packages/components/base/source/2-molecules/text-media/text-media.scss
@@ -43,7 +43,7 @@
     .text-media--intext & {
       padding-bottom: var(--ks-spacing-s);
 
-      @include container.size('≥' 600px) {
+      @include container.size('≥', 600px) {
         padding-bottom: var(--ks-spacing-xs);
         max-width: 50%;
         min-width: 0;
@@ -55,14 +55,14 @@
     }
 
     .text-media--intext.text-media--left & {
-      @include container.size('≥' 600px) {
+      @include container.size('≥', 600px) {
         float: left;
         padding-right: var(--ks-spacing-m);
       }
     }
 
     .text-media--intext.text-media--right & {
-      @include container.size('≥' 600px) {
+      @include container.size('≥', 600px) {
         float: right;
         padding-left: var(--ks-spacing-m);
       }

--- a/packages/components/content/source/2-molecules/collapsible-box/collapsible-box.scss
+++ b/packages/components/content/source/2-molecules/collapsible-box/collapsible-box.scss
@@ -37,7 +37,7 @@ $vars: meta.module-variables(collapsible-box-vars);
     &__text {
       flex: 1;
 
-      @include container.size('≥' 640px) {
+      @include container.size('≥', 640px) {
         padding-right: 1em;
       }
     }

--- a/packages/components/content/source/2-molecules/quote/quote.scss
+++ b/packages/components/content/source/2-molecules/quote/quote.scss
@@ -10,7 +10,7 @@ $vars: meta.module-variables(quote-vars);
 .c-quote {
   align-items: var(--c-quote--align);
 
-  @include container.size('≥' 640px) {
+  @include container.size('≥', 640px) {
     display: flex;
   }
 
@@ -20,7 +20,7 @@ $vars: meta.module-variables(quote-vars);
     text-align: center;
     margin-bottom: 1rem;
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       margin-bottom: 0;
     }
   }

--- a/packages/components/content/source/2-molecules/storytelling/storytelling.scss
+++ b/packages/components/content/source/2-molecules/storytelling/storytelling.scss
@@ -19,7 +19,7 @@ $vars: meta.module-variables(storytelling-vars);
   padding: var(--c-storytelling--vertical-padding)
     var(--c-storytelling--horizontal-padding);
 
-  @include container.size('≥' 640px) {
+  @include container.size('≥', 640px) {
     flex-direction: row;
   }
 
@@ -42,7 +42,7 @@ $vars: meta.module-variables(storytelling-vars);
       margin-bottom: 0;
     }
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       padding-right: var(--c-storytelling--horizontal-padding);
       margin-bottom: 0;
 
@@ -51,7 +51,7 @@ $vars: meta.module-variables(storytelling-vars);
       }
     }
 
-    @include container.size('≥' 960px) {
+    @include container.size('≥', 960px) {
       // margin-bottom: 0;
 
       .c-storytelling--full & {
@@ -69,7 +69,7 @@ $vars: meta.module-variables(storytelling-vars);
       img {
         margin-top: calc(-1 * var(--c-storytelling--vertical-padding));
 
-        @include container.size('<' 640px) {
+        @include container.size('<', 640px) {
           .c-storytelling--order-mobile-image-last & {
             margin-top: 0;
           }
@@ -89,7 +89,7 @@ $vars: meta.module-variables(storytelling-vars);
           margin-bottom: calc(-1 * var(--c-storytelling--vertical-padding));
         }
 
-        @include container.size('≥' 640px) {
+        @include container.size('≥', 640px) {
           margin-bottom: calc(-1 * var(--c-storytelling--vertical-padding));
         }
       }
@@ -120,7 +120,7 @@ $vars: meta.module-variables(storytelling-vars);
     }
 
     .c-storytelling--order-mobile-image-last & {
-      @include container.size('<' 640px) {
+      @include container.size('<', 640px) {
         order: 2;
         margin-bottom: 0;
         margin-top: 1rem;
@@ -128,7 +128,7 @@ $vars: meta.module-variables(storytelling-vars);
     }
 
     .c-storytelling--order-desktop-image-last & {
-      @include container.size('≥' 640px) {
+      @include container.size('≥', 640px) {
         order: 2;
         padding-right: 0;
         padding-left: var(--c-storytelling--horizontal-padding);
@@ -139,11 +139,11 @@ $vars: meta.module-variables(storytelling-vars);
     .c-storytelling--full.c-storytelling--order-desktop-image-last & {
       padding: 0;
 
-      @include container.size('≥' 640px) {
+      @include container.size('≥', 640px) {
         padding: 0;
       }
 
-      @include container.size('≥' 960px) {
+      @include container.size('≥', 960px) {
         padding: 0;
       }
     }
@@ -199,7 +199,7 @@ $vars: meta.module-variables(storytelling-vars);
     justify-content: center;
     align-items: center;
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       padding-left: var(--c-storytelling--horizontal-padding);
     }
 
@@ -218,7 +218,7 @@ $vars: meta.module-variables(storytelling-vars);
     &--right {
       justify-content: flex-start;
 
-      @include container.size('≥' 640px) {
+      @include container.size('≥', 640px) {
         justify-content: flex-end;
       }
     }
@@ -231,7 +231,7 @@ $vars: meta.module-variables(storytelling-vars);
     .c-storytelling--order-desktop-image-last & {
       padding-left: 0;
 
-      @include container.size('≥' 640px) {
+      @include container.size('≥', 640px) {
         padding-right: var(--c-storytelling--horizontal-padding);
       }
     }

--- a/packages/components/content/source/2-molecules/visual-slider/visual-slider.scss
+++ b/packages/components/content/source/2-molecules/visual-slider/visual-slider.scss
@@ -12,14 +12,14 @@ $vars: meta.module-variables(visual-slider-vars);
 .c-visual-slider {
   // hide preview on small screens
   .c-visual-slide--preview {
-    @include container.size('<' 639px) {
+    @include container.size('<', 639px) {
       @include bourbon.hide-visually;
     }
   }
 
   // hide bullets on large screens
   .c-slider__bullet {
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       display: none;
     }
   }
@@ -27,7 +27,7 @@ $vars: meta.module-variables(visual-slider-vars);
   .c-slider-nav {
     margin-top: 0.5em;
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       margin-top: 0;
       border-bottom: 1px solid var(--c-visual-slider_nav--border-bottom-color);
     }

--- a/packages/components/content/source/2-molecules/visual/_visual__box.scss
+++ b/packages/components/content/source/2-molecules/visual/_visual__box.scss
@@ -17,12 +17,12 @@
     color: inherit;
   }
 
-  @include container.size('≥' 640px) {
+  @include container.size('≥', 640px) {
     width: auto;
     border-radius: var(--c-visual_box--border-radius);
   }
 
-  @include container.size('≥' 1200px) {
+  @include container.size('≥', 1200px) {
     padding-top: 3rem;
     padding-bottom: 3rem;
   }
@@ -40,7 +40,7 @@
       border-radius: 0;
     }
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       background: none;
       padding: 0 !important;
       border-radius: 0;

--- a/packages/components/content/source/2-molecules/visual/_visual__content.scss
+++ b/packages/components/content/source/2-molecules/visual/_visual__content.scss
@@ -7,7 +7,7 @@
   width: 100%;
   margin: auto;
 
-  @include container.size('≥' 640px) {
+  @include container.size('≥', 640px) {
     padding: var(--l-section--content-padding);
     flex-grow: 1; // = 100% height
   }
@@ -43,7 +43,7 @@
   }
 
   .c-visual--no-crop & {
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       @include bourbon.position(absolute, 0);
     }
   }

--- a/packages/components/content/source/2-molecules/visual/visual.scss
+++ b/packages/components/content/source/2-molecules/visual/visual.scss
@@ -41,7 +41,7 @@ $vars: meta.module-variables(visual-vars);
       flex-grow: 1;
     }
 
-    @include container.size('≥' 640px) {
+    @include container.size('≥', 640px) {
       @include bourbon.position(absolute, 0);
 
       .c-visual--no-crop & {

--- a/packages/components/core/source/core/_container.scss
+++ b/packages/components/core/source/core/_container.scss
@@ -9,12 +9,8 @@ $unit-intervals: (
   'px': 1,
   // 'em': 0.01,
   // 'rem': 0.1,
-  // '': 0,,,
+  // '': 0,,,,
 ) !default;
-
-@if not $name {
-  @error '$name has to be configured (See https://sass-lang.com/documentation/at-rules/use#configuration)';
-}
 
 @mixin wrapper {
   @at-root {
@@ -50,12 +46,16 @@ $unit-intervals: (
   @return $value;
 }
 
-@mixin size($expression) {
-  $operator: get-operator(list.nth($expression, 1));
-  $value: get-value(list.nth($expression, 2), $operator);
+@mixin size($operator, $value, $localName: $name) {
+  @if not $localName {
+    @error '$localName undefined';
+  }
+
+  $operator: get-operator($operator);
+  $value: get-value($value, $operator);
   $prefix: if(list.index(('<', '<=', '≤'), $operator), 'max', 'min');
 
-  @container #{$name} size(#{string.unquote('#{$prefix}-width: #{$value}')}) {
+  @container #{$localName} size(#{string.unquote('#{$prefix}-width: #{$value}')}) {
     @content;
   }
 }


### PR DESCRIPTION
Name can now be explicitly added in mixin use (last parameter, `$name`), to avoid pitfalls with multiple sass module inclusions specifying `with` (be it `@use` or `@forward`). This becomes a problem, when the same entry point uses the mixin twice, with different names.

This can now be avoided by giving the explicit `$name`. Also enables more free form use, or having multiple containers in a single component.

For local re-use:
```scss
@use '@kickstartds/core/source/core/container';

@mixin size ($operator, $value) {
  @include container.size($operator, $value, 'container-name');
}
```