### PR TITLE
Fix text-media intext media alignment

### DIFF
--- a/packages/components/base/source/text-media/text-media.scss
+++ b/packages/components/base/source/text-media/text-media.scss
@@ -93,4 +93,8 @@
     text-align: left;
     color: var(--ks-text-color-default);
   }
+
+  .l-container--rich-text {
+    display: contents;
+  }
 }


### PR DESCRIPTION
resolves #1273
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.0.4-canary.1274.5548.0
  npm install @kickstartds/blog@2.0.4-canary.1274.5548.0
  npm install @kickstartds/form@2.0.4-canary.1274.5548.0
  # or 
  yarn add @kickstartds/base@2.0.4-canary.1274.5548.0
  yarn add @kickstartds/blog@2.0.4-canary.1274.5548.0
  yarn add @kickstartds/form@2.0.4-canary.1274.5548.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
