### PR TITLE
Add missing object types to schemas

### DIFF
--- a/packages/components/blog/source/post-share-bar/post-share-bar.schema.json
+++ b/packages/components/blog/source/post-share-bar/post-share-bar.schema.json
@@ -6,6 +6,7 @@
   "type": "object",
   "properties": {
     "headline": {
+      "type": "object",
       "allOf": [
         {
           "type": "object",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/blog@2.0.4-canary.1275.5555.0
  # or 
  yarn add @kickstartds/blog@2.0.4-canary.1275.5555.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
