### PR TITLE
Simplify section headline referencing

### DIFF
--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -94,14 +94,8 @@
           "type": "object",
           "properties": {
             "align": {
-              "allOf": [
-                {
-                  "default": "center"
-                },
-                {
-                  "$ref": "http://schema.kickstartds.com/base/headline.schema.json#/properties/align"
-                }
-              ]
+              "type": "string",
+              "default": "center"
             }
           }
         },


### PR DESCRIPTION
Currenty we nest `allOf`, which is fine... but not needed. This can make things more difficult down-stream, though. So a simpler solution for the same result is strictly better here.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.0.4-canary.1299.5738.0
  npm install @kickstartds/blog@2.0.4-canary.1299.5738.0
  npm install @kickstartds/core@2.0.4-canary.1299.5738.0
  npm install @kickstartds/form@2.0.4-canary.1299.5738.0
  npm install @kickstartds/bundler@2.0.4-canary.1299.5738.0
  npm install @kickstartds/style-dictionary@2.0.1-canary.1299.5738.0
  # or 
  yarn add @kickstartds/base@2.0.4-canary.1299.5738.0
  yarn add @kickstartds/blog@2.0.4-canary.1299.5738.0
  yarn add @kickstartds/core@2.0.4-canary.1299.5738.0
  yarn add @kickstartds/form@2.0.4-canary.1299.5738.0
  yarn add @kickstartds/bundler@2.0.4-canary.1299.5738.0
  yarn add @kickstartds/style-dictionary@2.0.1-canary.1299.5738.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
