### PR TITLE
Don't render array length if length is `0`

### DIFF
--- a/packages/components/blog/source/post-meta/PostMetaComponent.tsx
+++ b/packages/components/blog/source/post-meta/PostMetaComponent.tsx
@@ -23,13 +23,13 @@ export const PostMetaComponent: ForwardRefRenderFunction<
         {author.name}
       </div>
     )}
-    {items &&
-      items.length &&
-      items.map(({ icon, text }, i) => (
-        <span className="c-post-meta__item" key={i}>
-          {icon && <Icon icon={icon} />}
-          {text}
-        </span>
-      ))}
+    {items && items.length
+      ? items.map(({ icon, text }, i) => (
+          <span className="c-post-meta__item" key={i}>
+            {icon && <Icon icon={icon} />}
+            {text}
+          </span>
+        ))
+      : null}
   </div>
 );

--- a/packages/components/blog/source/post-share-bar/PostShareBarComponent.tsx
+++ b/packages/components/blog/source/post-share-bar/PostShareBarComponent.tsx
@@ -17,17 +17,17 @@ export const PostShareBarComponent: ForwardRefRenderFunction<
     {...props}
   >
     {headline?.content && <Headline spaceAfter="small" {...headline} />}
-    {links &&
-      links.length &&
-      links.map(({ icon, newTab, ...linkProps }, i) => (
-        <Link
-          className="c-post-share-bar__link"
-          {...(newTab ? { target: '_blank', rel: 'noopener' } : {})}
-          {...linkProps}
-          key={i}
-        >
-          <Icon icon={icon} />
-        </Link>
-      ))}
+    {links && links.length
+      ? links.map(({ icon, newTab, ...linkProps }, i) => (
+          <Link
+            className="c-post-share-bar__link"
+            {...(newTab ? { target: '_blank', rel: 'noopener' } : {})}
+            {...linkProps}
+            key={i}
+          >
+            <Icon icon={icon} />
+          </Link>
+        ))
+      : null}
   </div>
 );

--- a/packages/components/blog/source/post-teaser/PostTeaserComponent.tsx
+++ b/packages/components/blog/source/post-teaser/PostTeaserComponent.tsx
@@ -34,14 +34,14 @@ export const PostTeaserComponent: ForwardRefRenderFunction<
     ref={ref}
     {...props}
   >
-    {categories && categories.length && (
+    {categories && categories.length ? (
       <TagLabelContainer
         tagLabels={categories.map((category) => ({
           ...category,
           size: 's',
         }))}
       />
-    )}
+    ) : null}
     <Teaser
       topic={title}
       text={body}

--- a/packages/components/form/source/form-check-group/checkbox-group/CheckboxGroupComponent.tsx
+++ b/packages/components/form/source/form-check-group/checkbox-group/CheckboxGroupComponent.tsx
@@ -35,11 +35,11 @@ export const CheckboxGroupComponent: ForwardRefRenderFunction<
   >
     <span className="c-form-check-group__label">{renderLabel(label)}</span>
     <div className="c-form-check-group__group" role="presentation">
-      {options &&
-        options.length &&
-        options.map((option, index) => (
-          <Checkbox {...option} name={name} key={`checkbox-${index}`} />
-        ))}
+      {options && options.length
+        ? options.map((option, index) => (
+            <Checkbox {...option} name={name} key={`checkbox-${index}`} />
+          ))
+        : null}
       {invalid && invalidMessage && (
         <p className="c-form-check__invalid-message">{invalidMessage}</p>
       )}

--- a/packages/components/form/source/form-check-group/radio-group/RadioGroupComponent.tsx
+++ b/packages/components/form/source/form-check-group/radio-group/RadioGroupComponent.tsx
@@ -35,11 +35,11 @@ export const RadioGroupComponent: ForwardRefRenderFunction<
   >
     <span className="c-form-check-group__label">{renderLabel(label)}</span>
     <div className="c-form-check-group__group" role="presentation">
-      {options &&
-        options.length &&
-        options.map((option, index) => (
-          <Radio {...option} name={name} key={`radio-${index}`} />
-        ))}
+      {options && options.length
+        ? options.map((option, index) => (
+            <Radio {...option} name={name} key={`radio-${index}`} />
+          ))
+        : null}
       {invalid && invalidMessage && (
         <p className="c-form-check__invalid-message">{invalidMessage}</p>
       )}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.0.4-canary.1301.5742.0
  npm install @kickstartds/blog@2.0.4-canary.1301.5742.0
  npm install @kickstartds/core@2.0.4-canary.1301.5742.0
  npm install @kickstartds/form@2.0.4-canary.1301.5742.0
  npm install @kickstartds/bundler@2.0.4-canary.1301.5742.0
  npm install @kickstartds/style-dictionary@2.0.1-canary.1301.5742.0
  # or 
  yarn add @kickstartds/base@2.0.4-canary.1301.5742.0
  yarn add @kickstartds/blog@2.0.4-canary.1301.5742.0
  yarn add @kickstartds/core@2.0.4-canary.1301.5742.0
  yarn add @kickstartds/form@2.0.4-canary.1301.5742.0
  yarn add @kickstartds/bundler@2.0.4-canary.1301.5742.0
  yarn add @kickstartds/style-dictionary@2.0.1-canary.1301.5742.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@2.0.4-next.4`
`@kickstartds/blog@2.0.4-next.5`
`@kickstartds/bundler@2.0.4-next.1`
`@kickstartds/core@2.0.4-next.2`
`@kickstartds/form@2.0.4-next.4`
`@kickstartds/style-dictionary@2.0.1-next.1`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Master [#1278](https://github.com/kickstartDS/kickstartDS/pull/1278) ([@julrich](https://github.com/julrich) [@fleven-kds](https://github.com/fleven-kds) [@lmestel](https://github.com/lmestel) [@DanielLeyUX](https://github.com/DanielLeyUX))
  - `@kickstartds/blog`, `@kickstartds/form`
    - Don't render array length if length is `0` [#1301](https://github.com/kickstartDS/kickstartDS/pull/1301) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/bundler`
    - fix babel targets [#1277](https://github.com/kickstartDS/kickstartDS/pull/1277) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/form`
    - narrow component prop types [#1276](https://github.com/kickstartDS/kickstartDS/pull/1276) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/style-dictionary`
    - split style-dictionary scripts [#1250](https://github.com/kickstartDS/kickstartDS/pull/1250) ([@lmestel](https://github.com/lmestel))
  - `@kickstartds/blog`
    - Add missing object types to schemas [#1275](https://github.com/kickstartDS/kickstartDS/pull/1275) ([@julrich](https://github.com/julrich))
  - `@kickstartds/base`
    - Fix text-media intext media alignment [#1274](https://github.com/kickstartDS/kickstartDS/pull/1274) ([@lmestel](https://github.com/lmestel))
  
  #### 🏠 Internal
  
  - run ci jobs on dependabot branches [#1279](https://github.com/kickstartDS/kickstartDS/pull/1279) ([@lmestel](https://github.com/lmestel))
  
  #### 🔩 Dependency Updates
  
  - build(deps): bump json5 from 1.0.1 to 1.0.2 [#1241](https://github.com/kickstartDS/kickstartDS/pull/1241) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump @sideway/formula from 3.0.0 to 3.0.1 [#1281](https://github.com/kickstartDS/kickstartDS/pull/1281) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump http-cache-semantics from 4.1.0 to 4.1.1 [#1249](https://github.com/kickstartDS/kickstartDS/pull/1249) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump ua-parser-js from 0.7.31 to 0.7.35 [#1285](https://github.com/kickstartDS/kickstartDS/pull/1285) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump qs from 6.5.2 to 6.5.3 [#1233](https://github.com/kickstartDS/kickstartDS/pull/1233) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump decode-uri-component from 0.2.0 to 0.2.2 [#1212](https://github.com/kickstartDS/kickstartDS/pull/1212) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - build(deps): bump loader-utils from 1.4.0 to 1.4.2 [#1188](https://github.com/kickstartDS/kickstartDS/pull/1188) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/bundler`
    - build(deps): bump typescript from 4.8.4 to 4.9.5 [#1246](https://github.com/kickstartDS/kickstartDS/pull/1246) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
    - build(deps): bump @rollup/plugin-babel from 5.3.1 to 6.0.3 [#1210](https://github.com/kickstartDS/kickstartDS/pull/1210) ([@dependabot[bot]](https://github.com/dependabot[bot]))
    - build(deps): bump @rollup/plugin-node-resolve from 15.0.0 to 15.0.2 [#1288](https://github.com/kickstartDS/kickstartDS/pull/1288) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/bundler`, `@kickstartds/style-dictionary`
    - build(deps): bump postcss from 8.4.17 to 8.4.21 [#1242](https://github.com/kickstartDS/kickstartDS/pull/1242) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/style-dictionary`
    - build(deps): bump postcss-normalize-whitespace from 5.1.1 to 6.0.0 [#1290](https://github.com/kickstartDS/kickstartDS/pull/1290) ([@dependabot[bot]](https://github.com/dependabot[bot]))
  - `@kickstartds/base`, `@kickstartds/blog`, `@kickstartds/core`, `@kickstartds/form`, `@kickstartds/bundler`, `@kickstartds/style-dictionary`
    - build(deps): bump @babel/core from 7.19.6 to 7.21.4 [#1289](https://github.com/kickstartDS/kickstartDS/pull/1289) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@lmestel](https://github.com/lmestel))
  
  #### Authors: 5
  
  - [@dependabot[bot]](https://github.com/dependabot[bot])
  - Daniel ([@DanielLeyUX](https://github.com/DanielLeyUX))
  - Franz ([@fleven-kds](https://github.com/fleven-kds))
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
