### PR TITLE
Remove section gutter when option is set to `none`

### DIFF
--- a/packages/components/base/source/section/_section-vars.scss
+++ b/packages/components/base/source/section/_section-vars.scss
@@ -29,6 +29,9 @@ $host: (
   '.l-section__container': (
     gutter: var(--l-section--gutter-default),
   ),
+  '.l-section__container--gutter-none': (
+    gutter: 0,
+  ),
   '.l-section__container--gutter-small': (
     gutter: var(--l-section--gutter-small),
   ),


### PR DESCRIPTION
Fixes #1332
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.0.4-canary.1333.5856.0
  npm install @kickstartds/blog@2.0.4-canary.1333.5856.0
  npm install @kickstartds/form@2.0.4-canary.1333.5856.0
  # or 
  yarn add @kickstartds/base@2.0.4-canary.1333.5856.0
  yarn add @kickstartds/blog@2.0.4-canary.1333.5856.0
  yarn add @kickstartds/form@2.0.4-canary.1333.5856.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
