### PR TITLE
Trigger another release

### DIFF
--- a/packages/components/base/README.md
+++ b/packages/components/base/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/components/base/package.json
+++ b/packages/components/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/base",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "kickstartDS Base Module",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {

--- a/packages/components/blog/README.md
+++ b/packages/components/blog/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/components/blog/package.json
+++ b/packages/components/blog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/blog",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "kickstartDS Blog Module",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {

--- a/packages/components/core/README.md
+++ b/packages/components/core/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/components/core/package.json
+++ b/packages/components/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/core",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "kickstartDS Core Module",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {

--- a/packages/components/form/README.md
+++ b/packages/components/form/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/components/form/package.json
+++ b/packages/components/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/form",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "kickstartDS Form Module",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {

--- a/packages/tools/bundler/package.json
+++ b/packages/tools/bundler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/bundler",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "kickstartDS Component Bundler",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {

--- a/packages/tools/docusaurus/README.md
+++ b/packages/tools/docusaurus/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/tools/docusaurus/package.json
+++ b/packages/tools/docusaurus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds-internal/docusaurus",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "private": true,
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://www.kickstartDS.com",

--- a/packages/tools/style-dictionary/README.md
+++ b/packages/tools/style-dictionary/README.md
@@ -10,7 +10,7 @@ https://www.kickstartds.com/docs/intro/packages
 Or see some background about component modules specifically:<br/>
 https://www.kickstartds.com/docs/foundations/modules
 
-See `CHANGELOG.md` for version history!
+See `CHANGELOG.md` for version history.
 
 ## Contributing
 

--- a/packages/tools/style-dictionary/package.json
+++ b/packages/tools/style-dictionary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kickstartds/style-dictionary",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "kickstartDS Style Dictionary Config",
   "homepage": "https://www.kickstartDS.com",
   "bugs": {


### PR DESCRIPTION
`2.1.0` wasn't released completely, because of missing permissions after activating branch protection for `master`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.1.1-canary.1370.5937.0
  npm install @kickstartds/blog@2.1.1-canary.1370.5937.0
  npm install @kickstartds/core@2.1.1-canary.1370.5937.0
  npm install @kickstartds/form@2.1.1-canary.1370.5937.0
  npm install @kickstartds/bundler@2.1.1-canary.1370.5937.0
  npm install @kickstartds/style-dictionary@2.1.1-canary.1370.5937.0
  # or 
  yarn add @kickstartds/base@2.1.1-canary.1370.5937.0
  yarn add @kickstartds/blog@2.1.1-canary.1370.5937.0
  yarn add @kickstartds/core@2.1.1-canary.1370.5937.0
  yarn add @kickstartds/form@2.1.1-canary.1370.5937.0
  yarn add @kickstartds/bundler@2.1.1-canary.1370.5937.0
  yarn add @kickstartds/style-dictionary@2.1.1-canary.1370.5937.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
