### PR TITLE
Fix createTokens import

### DIFF
--- a/packages/tools/style-dictionary/writeTokens.js
+++ b/packages/tools/style-dictionary/writeTokens.js
@@ -1,6 +1,6 @@
 const { writeFile } = require('fs/promises');
 const path = require('path');
-const { createTokens } = require('./createTokens');
+const createTokens = require('./createTokens');
 
 module.exports = (primitives, folder) =>
   Promise.all(


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.2.1-canary.1406.5989.0
  npm install @kickstartds/blog@2.2.1-canary.1406.5989.0
  npm install @kickstartds/core@2.2.1-canary.1406.5989.0
  npm install @kickstartds/form@2.2.1-canary.1406.5989.0
  npm install @kickstartds/style-dictionary@2.2.1-canary.1406.5989.0
  # or 
  yarn add @kickstartds/base@2.2.1-canary.1406.5989.0
  yarn add @kickstartds/blog@2.2.1-canary.1406.5989.0
  yarn add @kickstartds/core@2.2.1-canary.1406.5989.0
  yarn add @kickstartds/form@2.2.1-canary.1406.5989.0
  yarn add @kickstartds/style-dictionary@2.2.1-canary.1406.5989.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
