### PR TITLE
Fix naming of `Text media` anyOf entries

### DIFF
--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -500,7 +500,7 @@ export type Caption3 = string;
 /**
  * Collection of media items to display
  */
-export type Media = (TextMediaVideo | TextMediaImage | TextMediaLazyImage)[];
+export type Media = (MediaVideo | MediaImage | MediaLazyImage)[];
 /**
  * Additional css classes attached to the wrapping element
  */
@@ -952,7 +952,7 @@ export interface TextMedia {
   className?: Class2;
   component?: KsComponentAttribute14;
 }
-export interface TextMediaVideo {
+export interface MediaVideo {
   video?: Video;
   full?: FullWidthMedia;
   caption?: Caption;
@@ -967,7 +967,7 @@ export interface Video {
   width: Width2;
   height: Height1;
 }
-export interface TextMediaImage {
+export interface MediaImage {
   image?: Picture1;
   full?: FullWidthMedia1;
   caption?: Caption1;
@@ -991,7 +991,7 @@ export interface Picture1 {
   sources?: Sources1;
   pictureClassName?: ClassAttribute1;
 }
-export interface TextMediaLazyImage {
+export interface MediaLazyImage {
   lightboxImage?: LightboxImage;
   full?: FullWidthMedia2;
   caption?: Caption3;

--- a/packages/components/base/source/text-media/TextMediaComponent.tsx
+++ b/packages/components/base/source/text-media/TextMediaComponent.tsx
@@ -11,9 +11,9 @@ import { IframeRatio } from '../iframe';
 import { RichText, defaultRenderFn } from '../rich-text';
 import {
   TextMediaProps as TextMediaSchemaProps,
-  TextMediaVideo as IVideo,
-  TextMediaImage as IImage,
-  TextMediaLazyImage as ILightboxImage,
+  MediaVideo as IVideo,
+  MediaImage as IImage,
+  MediaLazyImage as ILightboxImage,
   Media as IMedia,
   FullWidthMedia as TFullWidthMedia,
   Caption as TCaption,

--- a/packages/components/base/source/text-media/TextMediaProps.ts
+++ b/packages/components/base/source/text-media/TextMediaProps.ts
@@ -157,7 +157,7 @@ export type Caption3 = string;
 /**
  * Collection of media items to display
  */
-export type Media = (TextMediaVideo | TextMediaImage | TextMediaLazyImage)[];
+export type Media = (MediaVideo | MediaImage | MediaLazyImage)[];
 /**
  * Additional css classes attached to the wrapping element
  */
@@ -177,7 +177,7 @@ export interface TextMediaProps {
   className?: Class;
   component?: KsComponentAttribute2;
 }
-export interface TextMediaVideo {
+export interface MediaVideo {
   video?: Video;
   full?: FullWidthMedia;
   caption?: Caption;
@@ -192,7 +192,7 @@ export interface Video {
   width: Width;
   height: Height;
 }
-export interface TextMediaImage {
+export interface MediaImage {
   image?: Picture;
   full?: FullWidthMedia1;
   caption?: Caption1;
@@ -216,7 +216,7 @@ export interface Picture {
   sources?: Sources;
   pictureClassName?: ClassAttribute;
 }
-export interface TextMediaLazyImage {
+export interface MediaLazyImage {
   lightboxImage?: LightboxImage;
   full?: FullWidthMedia2;
   caption?: Caption3;

--- a/packages/components/base/source/text-media/text-media.schema.json
+++ b/packages/components/base/source/text-media/text-media.schema.json
@@ -40,7 +40,7 @@
         "anyOf": [
           {
             "type": "object",
-            "title": "TextMediaVideo",
+            "title": "MediaVideo",
             "properties": {
               "video": {
                 "title": "Video",
@@ -95,7 +95,7 @@
             "additionalProperties": false
           },
           {
-            "title": "TextMediaImage",
+            "title": "MediaImage",
             "type": "object",
             "properties": {
               "image": {
@@ -111,7 +111,7 @@
             "additionalProperties": false
           },
           {
-            "title": "TextMediaLazyImage",
+            "title": "MediaLazyImage",
             "type": "object",
             "properties": {
               "lightboxImage": {


### PR DESCRIPTION
Titles don't match our (new) type generation naming scheme.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.2.1-canary.1454.6068.0
  npm install @kickstartds/blog@2.2.1-canary.1454.6068.0
  npm install @kickstartds/form@2.2.1-canary.1454.6068.0
  # or 
  yarn add @kickstartds/base@2.2.1-canary.1454.6068.0
  yarn add @kickstartds/blog@2.2.1-canary.1454.6068.0
  yarn add @kickstartds/form@2.2.1-canary.1454.6068.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
