### PR TITLE
Fix json schema types in generated stories

### DIFF
--- a/packages/tools/bundler/stories/createStory.js
+++ b/packages/tools/bundler/stories/createStory.js
@@ -6,25 +6,27 @@ const template = ({
   componentName,
   componentPascalcased,
   schema,
-  loadComponentTokens,
+  hasComponentTokens,
 }) => `
 import type { Meta, StoryObj } from '@storybook/react';
+import type { JSONSchema7 } from "json-schema";
 import { getArgsShared } from "@kickstartds/core/lib/storybook";
 import { ${componentPascalcased} } from './index.js';
 ${
-  loadComponentTokens
+  hasComponentTokens
     ? `import cssprops from './${componentName}-tokens.json';`
     : ''
 }
 
-const schema = ${JSON.stringify(schema, null, 2)};
+const schema: JSONSchema7 = ${JSON.stringify(schema, null, 2)};
 
 const meta: Meta<typeof ${componentPascalcased}> = {
   title: '${capitalCase(moduleDir)}/${capitalCase(schema.title)}',
   component: ${componentPascalcased},
   excludeStories: ['Template'],
   parameters: {
-    ${loadComponentTokens ? 'cssprops,' : ''}
+    ${hasComponentTokens ? 'cssprops,' : ''}
+    jsonschema: schema,
   },
   ...getArgsShared(schema),
 };
@@ -41,18 +43,16 @@ const createStory = (schema, dest) => {
     `${dest}/${componentName}-tokens.json`
   );
   if (type === 'schema' && schema.properties) {
-    return Promise.all([
-      fs.outputFile(
-        `${dest}/${componentName}.stories.ts`,
-        template({
-          moduleDir,
-          componentName,
-          componentPascalcased: pascalCase(componentName),
-          schema,
-          hasComponentTokens,
-        })
-      ),
-    ]);
+    return fs.outputFile(
+      `${dest}/${componentName}.stories.ts`,
+      template({
+        moduleDir,
+        componentName,
+        componentPascalcased: pascalCase(componentName),
+        schema,
+        hasComponentTokens,
+      })
+    );
   }
 };
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.2.1-canary.1479.6195.0
  npm install @kickstartds/blog@2.2.1-canary.1479.6195.0
  npm install @kickstartds/core@2.2.1-canary.1479.6195.0
  npm install @kickstartds/form@2.2.1-canary.1479.6195.0
  npm install @kickstartds/bundler@2.2.1-canary.1479.6195.0
  npm install @kickstartds/style-dictionary@2.2.1-canary.1479.6195.0
  # or 
  yarn add @kickstartds/base@2.2.1-canary.1479.6195.0
  yarn add @kickstartds/blog@2.2.1-canary.1479.6195.0
  yarn add @kickstartds/core@2.2.1-canary.1479.6195.0
  yarn add @kickstartds/form@2.2.1-canary.1479.6195.0
  yarn add @kickstartds/bundler@2.2.1-canary.1479.6195.0
  yarn add @kickstartds/style-dictionary@2.2.1-canary.1479.6195.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
