### PR TITLE
Section content alignment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,6 @@
     "statusBarItem.hoverBackground": "#097d9a",
     "statusBarItem.remoteBackground": "#06566a",
     "statusBarItem.remoteForeground": "#e7e7e7",
-    "tab.activeBorder": "#097d9a",
     "titleBar.activeBackground": "#06566a",
     "titleBar.activeForeground": "#e7e7e7",
     "titleBar.inactiveBackground": "#06566a99",
@@ -18,5 +17,6 @@
     "commandCenter.border": "#e7e7e799"
   },
   "peacock.color": "#06566a",
+  "peacock.affectActivityBar": false,
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/components/base/source/headline/headline.scss
+++ b/packages/components/base/source/headline/headline.scss
@@ -8,25 +8,19 @@ $vars: meta.module-variables(headline-vars);
 @include container.wrapper;
 
 .c-headline {
-  margin: 0 auto var(--c-headline--space-after);
+  margin: 0 0 var(--c-headline--space-after);
   text-align: center;
 
   &--align-left {
-    margin-left: 0;
     text-align: left;
   }
 
   &--align-right {
-    margin-right: 0;
-    text-align: left;
+    text-align: right;
   }
 
   .l-section &:not(:first-child) {
     margin-top: calc(var(--c-headline--space-after) * 1.5);
-  }
-
-  @include container.size('≥', 640px) {
-    max-width: 70%;
   }
 
   &__headline {

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -40,10 +40,10 @@ export const SectionComponent: ForwardRefRenderFunction<
     spaceAfter = 'default',
     headline,
     width = 'default',
-    headlineWidth = 'unset',
-    headlineAlign = 'center',
     contentWidth = 'unset',
     contentAlign = 'center',
+    headlineWidth = 'unset',
+    headlineAlign = contentAlign,
     gutter = 'default',
     mode = 'default',
     className,
@@ -76,13 +76,7 @@ export const SectionComponent: ForwardRefRenderFunction<
     >
       {headline && headline.content && (
         <SectionContainer
-          width={
-            headlineWidth !== 'unset'
-              ? headlineWidth !== 'default'
-                ? headlineWidth
-                : undefined
-              : width
-          }
+          width={headlineWidth !== 'unset' ? headlineWidth : undefined}
           align={headlineAlign}
         >
           <Headline align={headlineAlign} {...headline} />
@@ -90,13 +84,7 @@ export const SectionComponent: ForwardRefRenderFunction<
       )}
       {children && (
         <SectionContainer
-          width={
-            contentWidth !== 'unset'
-              ? contentWidth !== 'default'
-                ? contentWidth
-                : undefined
-              : width
-          }
+          width={contentWidth !== 'unset' ? contentWidth : undefined}
           align={contentAlign}
           gutter={gutter}
           mode={mode}

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -1,31 +1,24 @@
-import {
-  FunctionComponent,
-  ForwardRefRenderFunction,
-  HTMLAttributes,
-  PropsWithChildren,
-} from 'react';
+import { ForwardRefRenderFunction, HTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { Headline } from '../headline';
 import type { SectionProps } from './typing';
 
-const SectionContainer: FunctionComponent<
-  PropsWithChildren<SectionProps & { align?: 'left' | 'center' | 'right' }>
-> = ({ width, align, gutter, mode, className, children }) => (
-  <div
-    className={classnames(
-      'l-section__container',
-      className,
-      width && `l-section__container--${width}`,
-      align && align !== 'center' && `l-section__container--${align}`,
-      gutter &&
-        gutter !== 'default' &&
-        `l-section__container--gutter-${gutter}`,
-      mode && mode !== 'default' && `l-section__container--${mode}`
-    )}
-  >
-    {children}
-  </div>
-);
+const containerClassName = (
+  {
+    width,
+    align,
+    gutter,
+    mode,
+  }: SectionProps & { align?: 'left' | 'center' | 'right' },
+  className = 'l-section__container'
+) =>
+  classnames(
+    className,
+    width && `${className}--${width}`,
+    align && align !== 'center' && `${className}--${align}`,
+    gutter && gutter !== 'default' && `${className}--gutter-${gutter}`,
+    mode && mode !== 'default' && `${className}--${mode}`
+  );
 
 export { SectionProps };
 
@@ -70,28 +63,34 @@ export const SectionComponent: ForwardRefRenderFunction<
     ref={ref}
     {...props}
   >
-    <SectionContainer
-      width={width !== 'default' ? width : undefined}
-      className="l-section__container--wrap"
+    <div
+      className={containerClassName(
+        { width: width !== 'default' ? width : undefined },
+        'l-section__content'
+      )}
     >
       {headline && headline.content && (
-        <SectionContainer
-          width={headlineWidth !== 'unset' ? headlineWidth : undefined}
-          align={headlineAlign}
+        <div
+          className={containerClassName({
+            width: headlineWidth !== 'unset' ? headlineWidth : undefined,
+            align: headlineAlign,
+          })}
         >
           <Headline align={headlineAlign} {...headline} />
-        </SectionContainer>
+        </div>
       )}
       {children && (
-        <SectionContainer
-          width={contentWidth !== 'unset' ? contentWidth : undefined}
-          align={contentAlign}
-          gutter={gutter}
-          mode={mode}
+        <div
+          className={containerClassName({
+            width: contentWidth !== 'unset' ? contentWidth : undefined,
+            align: contentAlign,
+            gutter,
+            mode,
+          })}
         >
           {children}
-        </SectionContainer>
+        </div>
       )}
-    </SectionContainer>
+    </div>
   </div>
 );

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -8,16 +8,15 @@ import classnames from 'classnames';
 import { Headline } from '../headline';
 import type { SectionProps } from './typing';
 
-const SectionContainer: FunctionComponent<PropsWithChildren<SectionProps>> = ({
-  width,
-  gutter,
-  mode,
-  children,
-}) => (
+const SectionContainer: FunctionComponent<
+  PropsWithChildren<SectionProps & { align?: 'left' | 'center' | 'right' }>
+> = ({ width, align, gutter, mode, className, children }) => (
   <div
     className={classnames(
       'l-section__container',
-      width && width !== 'default' && `l-section__container--${width}`,
+      className,
+      width && `l-section__container--${width}`,
+      align && align !== 'center' && `l-section__container--${align}`,
       gutter &&
         gutter !== 'default' &&
         `l-section__container--gutter-${gutter}`,
@@ -41,6 +40,10 @@ export const SectionComponent: ForwardRefRenderFunction<
     spaceAfter = 'default',
     headline,
     width = 'default',
+    headlineWidth = 'unset',
+    headlineAlign = 'center',
+    contentWidth = 'unset',
+    contentAlign = 'center',
     gutter = 'default',
     mode = 'default',
     className,
@@ -67,15 +70,40 @@ export const SectionComponent: ForwardRefRenderFunction<
     ref={ref}
     {...props}
   >
-    {headline && headline.content && (
-      <SectionContainer width={width}>
-        <Headline align="center" {...headline} />
-      </SectionContainer>
-    )}
-    {children && (
-      <SectionContainer width={width} gutter={gutter} mode={mode}>
-        {children}
-      </SectionContainer>
-    )}
+    <SectionContainer
+      width={width !== 'default' ? width : undefined}
+      className="l-section__container--wrap"
+    >
+      {headline && headline.content && (
+        <SectionContainer
+          width={
+            headlineWidth !== 'unset'
+              ? headlineWidth !== 'default'
+                ? headlineWidth
+                : undefined
+              : width
+          }
+          align={headlineAlign}
+        >
+          <Headline align={headlineAlign} {...headline} />
+        </SectionContainer>
+      )}
+      {children && (
+        <SectionContainer
+          width={
+            contentWidth !== 'unset'
+              ? contentWidth !== 'default'
+                ? contentWidth
+                : undefined
+              : width
+          }
+          align={contentAlign}
+          gutter={gutter}
+          mode={mode}
+        >
+          {children}
+        </SectionContainer>
+      )}
+    </SectionContainer>
   </div>
 );

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -8,7 +8,23 @@
 /**
  * Width of section to use
  */
-export type Width = 'full' | 'max' | 'wide' | 'default' | 'narrow';
+export type Width = 'narrow' | 'default' | 'wide' | 'max' | 'full';
+/**
+ * Width of headline to use
+ */
+export type HeadlineWidth = 'unset' | 'narrow' | 'default' | 'wide';
+/**
+ * Choose an alignment for the headline
+ */
+export type HeadlineAlignment = 'left' | 'center' | 'right';
+/**
+ * Width of content to use
+ */
+export type ContentWidth = 'unset' | 'narrow' | 'default' | 'wide';
+/**
+ * Choose an alignment for the content
+ */
+export type ContentAlignment = 'left' | 'center' | 'right';
 /**
  * Size of gutter to use
  */
@@ -770,6 +786,10 @@ export type KsComponentAttribute24 = string;
 
 export interface SectionProps {
   width?: Width;
+  headlineWidth?: HeadlineWidth;
+  headlineAlign?: HeadlineAlignment;
+  contentWidth?: ContentWidth;
+  contentAlign?: ContentAlignment;
   gutter?: Gutter;
   mode?: Mode;
   content?: Content;

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -8,8 +8,36 @@
       "type": "string",
       "title": "Width",
       "description": "Width of section to use",
-      "enum": ["full", "max", "wide", "default", "narrow"],
+      "enum": ["narrow", "default", "wide", "max", "full"],
       "default": "default"
+    },
+    "headlineWidth": {
+      "type": "string",
+      "title": "Headline Width",
+      "description": "Width of headline to use",
+      "enum": ["unset", "narrow", "default", "wide"],
+      "default": "unset"
+    },
+    "headlineAlign": {
+      "title": "Headline Alignment",
+      "description": "Choose an alignment for the headline",
+      "type": "string",
+      "enum": ["left", "center", "right"],
+      "default": "center"
+    },
+    "contentWidth": {
+      "type": "string",
+      "title": "Content Width",
+      "description": "Width of content to use",
+      "enum": ["unset", "narrow", "default", "wide"],
+      "default": "unset"
+    },
+    "contentAlign": {
+      "title": "Content Alignment",
+      "description": "Choose an alignment for the content",
+      "type": "string",
+      "enum": ["left", "center", "right"],
+      "default": "center"
     },
     "gutter": {
       "type": "string",

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -22,8 +22,7 @@
       "title": "Headline Alignment",
       "description": "Choose an alignment for the headline",
       "type": "string",
-      "enum": ["left", "center", "right"],
-      "default": "center"
+      "enum": ["left", "center", "right"]
     },
     "contentWidth": {
       "type": "string",
@@ -123,7 +122,7 @@
           "properties": {
             "align": {
               "type": "string",
-              "default": "center"
+              "default": null
             }
           }
         },

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -32,7 +32,6 @@ $vars: meta.module-variables(section-vars);
   }
 
   &__container {
-    padding: 0 var(--l-section--content-padding);
     margin: auto;
     width: 100%;
     max-width: var(--l-section--content-width-default);
@@ -59,8 +58,24 @@ $vars: meta.module-variables(section-vars);
     }
 
     &--full {
-      padding: 0;
       max-width: var(--l-section--content-width-full);
+    }
+
+    &--left {
+      margin-left: 0;
+    }
+
+    &--right {
+      margin-right: 0;
+    }
+
+    &--wrap {
+      display: block;
+      padding: 0 var(--l-section--content-padding);
+
+      &.l-section__container--full {
+        padding: 0;
+      }
     }
   }
 }

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -31,9 +31,23 @@ $vars: meta.module-variables(section-vars);
     padding-bottom: 0;
   }
 
+  &__content {
+    margin: auto;
+    padding: 0 var(--l-section--content-padding);
+    max-width: var(--l-section--content-width-default);
+
+    &--max {
+      max-width: var(--l-section--content-width-max);
+    }
+
+    &--full {
+      max-width: var(--l-section--content-width-full);
+      padding: 0;
+    }
+  }
+
   &__container {
     margin: auto;
-    width: 100%;
     display: grid;
     grid-template-columns: repeat(
       var(--l-section_col--repeat),
@@ -44,34 +58,8 @@ $vars: meta.module-variables(section-vars);
     );
     grid-gap: var(--l-section--gutter);
 
-    &--wrap {
-      display: block;
-      padding: 0 var(--l-section--content-padding);
-      max-width: var(--l-section--content-width-default);
-
-      &.l-section__container--full {
-        padding: 0;
-      }
-    }
-
-    &--narrow {
-      max-width: var(--l-section--content-width-narrow);
-    }
-
     &--default {
       max-width: var(--l-section--content-width-default);
-    }
-
-    &--wide {
-      max-width: var(--l-section--content-width-wide);
-    }
-
-    &--max {
-      max-width: var(--l-section--content-width-max);
-    }
-
-    &--full {
-      max-width: var(--l-section--content-width-full);
     }
 
     &--left {
@@ -80,6 +68,18 @@ $vars: meta.module-variables(section-vars);
 
     &--right {
       margin-right: 0;
+    }
+  }
+
+  &__content,
+  &__container {
+    width: 100%;
+
+    &--narrow {
+      max-width: var(--l-section--content-width-narrow);
+    }
+    &--wide {
+      max-width: var(--l-section--content-width-wide);
     }
   }
 }

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -34,7 +34,6 @@ $vars: meta.module-variables(section-vars);
   &__container {
     margin: auto;
     width: 100%;
-    max-width: var(--l-section--content-width-default);
     display: grid;
     grid-template-columns: repeat(
       var(--l-section_col--repeat),
@@ -45,8 +44,22 @@ $vars: meta.module-variables(section-vars);
     );
     grid-gap: var(--l-section--gutter);
 
+    &--wrap {
+      display: block;
+      padding: 0 var(--l-section--content-padding);
+      max-width: var(--l-section--content-width-default);
+
+      &.l-section__container--full {
+        padding: 0;
+      }
+    }
+
     &--narrow {
       max-width: var(--l-section--content-width-narrow);
+    }
+
+    &--default {
+      max-width: var(--l-section--content-width-default);
     }
 
     &--wide {
@@ -67,15 +80,6 @@ $vars: meta.module-variables(section-vars);
 
     &--right {
       margin-right: 0;
-    }
-
-    &--wrap {
-      display: block;
-      padding: 0 var(--l-section--content-padding);
-
-      &.l-section__container--full {
-        padding: 0;
-      }
     }
   }
 }

--- a/packages/components/core/source/storybook/helpers.ts
+++ b/packages/components/core/source/storybook/helpers.ts
@@ -50,6 +50,7 @@ const getArgsShared = (
     condition?: Conditional & { gt?: number }
   ) => {
     if ('const' in schema) return;
+    if (defaultValue == null) defaultValue = undefined;
 
     const schemaType = Array.isArray(schema.type)
       ? schema.type[0]
@@ -77,7 +78,8 @@ const getArgsShared = (
         if: condition,
         ...typeProps,
       };
-      args[name] = example ?? defaultValue;
+      const arg = example ?? defaultValue;
+      if (arg != null) args[name] = arg;
     };
 
     switch (schemaType) {


### PR DESCRIPTION
New Section Props:

- `contentWidth`: `unset` (default), `narrow`, `default`, `wide`
- `contentAlign`: `left`, `center` (default), `right`
- `headlineWidth`: `unset` (default), `narrow`, `default`, `wide`
- `headlineAlign`: `left`, `center`, `right` -  inherits from `contentAlign` if omitted

Resolves #1478 
Resolves #1235


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@3.0.0-canary.1486.6366.0
  npm install @kickstartds/blog@3.0.0-canary.1486.6366.0
  npm install @kickstartds/core@3.0.0-canary.1486.6366.0
  npm install @kickstartds/form@3.0.0-canary.1486.6366.0
  # or 
  yarn add @kickstartds/base@3.0.0-canary.1486.6366.0
  yarn add @kickstartds/blog@3.0.0-canary.1486.6366.0
  yarn add @kickstartds/core@3.0.0-canary.1486.6366.0
  yarn add @kickstartds/form@3.0.0-canary.1486.6366.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
