### PR TITLE
Restructure section props

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docusaurus-build": "yarn workspace @kickstartds-internal/docusaurus build",
     "eslint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "find-licenses": "node ./scripts/license.js",
-    "format": "prettier --cache --write .",
+    "format": "prettier --cache --list-different --write . || true",
     "git-config": "git config --local include.path ../.gitconfig",
     "husky-commit-msg": "commitlint -E GIT_PARAMS",
     "husky-pre-commit": "yarn run schema && git add packages/*/*/source/**/*Props.ts && lint-staged",

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -15,10 +15,12 @@ const containerClassName = (
     mode?: SectionProps['content']['mode'];
     align?: SectionProps['content']['align'];
   },
-  className = 'l-section__container'
+  className: string,
+  ...additionalClassNames: string[]
 ) =>
   classnames(
     className,
+    ...additionalClassNames,
     width && `${className}--${width}`,
     align && align !== 'center' && `${className}--${align}`,
     gutter && gutter !== 'default' && `${className}--gutter-${gutter}`,
@@ -51,11 +53,13 @@ export const SectionComponent: ForwardRefRenderFunction<
     align: contentAlign = 'center',
     gutter = 'default',
     mode = 'default',
+    className: contentClassName,
   } = content;
   const {
     width: headlineWidth = 'unset',
     align: headlineAlign = contentAlign,
     textAlign: headlineTextAlign,
+    className: headlineClassName,
     ...headlineProps
   } = headline;
   return (
@@ -84,10 +88,15 @@ export const SectionComponent: ForwardRefRenderFunction<
       >
         {headlineProps && headlineProps.content && (
           <div
-            className={containerClassName({
-              width: headlineWidth !== 'unset' ? headlineWidth : undefined,
-              align: headlineAlign,
-            })}
+            className={containerClassName(
+              {
+                width: headlineWidth !== 'unset' ? headlineWidth : undefined,
+                align: headlineAlign,
+              },
+              'l-section__container',
+              'l-section__container--headline',
+              headlineClassName
+            )}
           >
             <Headline
               align={headlineTextAlign || headlineAlign}
@@ -97,12 +106,17 @@ export const SectionComponent: ForwardRefRenderFunction<
         )}
         {children && (
           <div
-            className={containerClassName({
-              width: contentWidth !== 'unset' ? contentWidth : undefined,
-              align: contentAlign,
-              gutter,
-              mode,
-            })}
+            className={containerClassName(
+              {
+                width: contentWidth !== 'unset' ? contentWidth : undefined,
+                align: contentAlign,
+                gutter,
+                mode,
+              },
+              'l-section__container',
+              'l-section__container--content',
+              contentClassName
+            )}
           >
             {children}
           </div>

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -9,7 +9,12 @@ const containerClassName = (
     align,
     gutter,
     mode,
-  }: SectionProps & { align?: 'left' | 'center' | 'right' },
+  }: {
+    width?: SectionProps['width'];
+    gutter?: SectionProps['content']['gutter'];
+    mode?: SectionProps['content']['mode'];
+    align?: SectionProps['content']['align'];
+  },
   className = 'l-section__container'
 ) =>
   classnames(
@@ -24,73 +29,85 @@ export { SectionProps };
 
 export const SectionComponent: ForwardRefRenderFunction<
   HTMLDivElement,
-  SectionProps & HTMLAttributes<HTMLDivElement>
+  SectionProps & Omit<HTMLAttributes<HTMLDivElement>, 'content'>
 > = (
   {
     background = 'default',
     inverted,
     spaceBefore = 'default',
     spaceAfter = 'default',
-    headline,
     width = 'default',
-    contentWidth = 'unset',
-    contentAlign = 'center',
-    headlineWidth = 'unset',
-    headlineAlign = contentAlign,
-    gutter = 'default',
-    mode = 'default',
+    content = {} as SectionProps['content'],
+    headline = {} as SectionProps['headline'],
     className,
     component,
     children,
     ...props
   },
   ref
-) => (
-  <div
-    className={classnames(
-      'l-section',
-      background && background !== 'default' && `l-section--${background}`,
-      spaceBefore &&
-        spaceBefore !== 'default' &&
-        `l-section--space-before-${spaceBefore}`,
-      spaceAfter &&
-        spaceAfter !== 'default' &&
-        `l-section--space-after-${spaceAfter}`,
-      className
-    )}
-    ks-inverted={inverted?.toString()}
-    ks-component={component}
-    ref={ref}
-    {...props}
-  >
+) => {
+  const {
+    width: contentWidth = 'unset',
+    align: contentAlign = 'center',
+    gutter = 'default',
+    mode = 'default',
+  } = content;
+  const {
+    width: headlineWidth = 'unset',
+    align: headlineAlign = contentAlign,
+    textAlign: headlineTextAlign,
+    ...headlineProps
+  } = headline;
+  return (
     <div
-      className={containerClassName(
-        { width: width !== 'default' ? width : undefined },
-        'l-section__content'
+      className={classnames(
+        'l-section',
+        background && background !== 'default' && `l-section--${background}`,
+        spaceBefore &&
+          spaceBefore !== 'default' &&
+          `l-section--space-before-${spaceBefore}`,
+        spaceAfter &&
+          spaceAfter !== 'default' &&
+          `l-section--space-after-${spaceAfter}`,
+        className
       )}
+      ks-inverted={inverted?.toString()}
+      ks-component={component}
+      ref={ref}
+      {...props}
     >
-      {headline && headline.content && (
-        <div
-          className={containerClassName({
-            width: headlineWidth !== 'unset' ? headlineWidth : undefined,
-            align: headlineAlign,
-          })}
-        >
-          <Headline align={headlineAlign} {...headline} />
-        </div>
-      )}
-      {children && (
-        <div
-          className={containerClassName({
-            width: contentWidth !== 'unset' ? contentWidth : undefined,
-            align: contentAlign,
-            gutter,
-            mode,
-          })}
-        >
-          {children}
-        </div>
-      )}
+      <div
+        className={containerClassName(
+          { width: width !== 'default' ? width : undefined },
+          'l-section__content'
+        )}
+      >
+        {headlineProps && headlineProps.content && (
+          <div
+            className={containerClassName({
+              width: headlineWidth !== 'unset' ? headlineWidth : undefined,
+              align: headlineAlign,
+            })}
+          >
+            <Headline
+              align={headlineTextAlign || headlineAlign}
+              {...headlineProps}
+            />
+          </div>
+        )}
+        {children && (
+          <div
+            className={containerClassName({
+              width: contentWidth !== 'unset' ? contentWidth : undefined,
+              align: contentAlign,
+              gutter,
+              mode,
+            })}
+          >
+            {children}
+          </div>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -28,6 +28,10 @@ export type Gutter = 'large' | 'default' | 'small' | 'none';
  */
 export type Mode = 'default' | 'tile' | 'list';
 /**
+ * Additional css classes that should be applied to the content section container
+ */
+export type AdditionalContentClass = string;
+/**
  * Type of background
  */
 export type Background = 'default' | 'accent' | 'bold';
@@ -53,6 +57,10 @@ export type HeadlineBoxWidth = 'unset' | 'narrow' | 'default' | 'wide';
 export type HeadlineBoxAlignment = 'left' | 'center' | 'right';
 export type TextAlignment = 'left' | 'center' | 'right';
 /**
+ * Additional css classes that should be applied to the headline section container
+ */
+export type AdditionalHeadlineClass = string;
+/**
  * Add additional css classes that should be applied to the section
  */
 export type AdditionalClass = string;
@@ -68,6 +76,7 @@ export interface SectionProps {
     align?: ContentAlignment;
     gutter?: Gutter;
     mode?: Mode;
+    className?: AdditionalContentClass;
   };
   background?: Background;
   inverted?: Inverted;
@@ -77,6 +86,7 @@ export interface SectionProps {
     width?: HeadlineBoxWidth;
     align?: HeadlineBoxAlignment;
     textAlign?: TextAlignment;
+    className?: AdditionalHeadlineClass;
   } & HeadlineProps;
   className?: AdditionalClass;
   component?: KsComponentAttribute;

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -12,14 +12,6 @@ import type { HeadlineProps } from '@kickstartds/base/lib/headline/typing';
  */
 export type Width = 'narrow' | 'default' | 'wide' | 'max' | 'full';
 /**
- * Width of headline to use
- */
-export type HeadlineWidth = 'unset' | 'narrow' | 'default' | 'wide';
-/**
- * Choose an alignment for the headline
- */
-export type HeadlineAlignment = 'left' | 'center' | 'right';
-/**
  * Width of content to use
  */
 export type ContentWidth = 'unset' | 'narrow' | 'default' | 'wide';
@@ -52,6 +44,15 @@ export type SpaceBefore = 'default' | 'small' | 'none';
  */
 export type SpaceAfter = 'default' | 'small' | 'none';
 /**
+ * Width of headline to use
+ */
+export type HeadlineBoxWidth = 'unset' | 'narrow' | 'default' | 'wide';
+/**
+ * Choose an alignment for the headline
+ */
+export type HeadlineBoxAlignment = 'left' | 'center' | 'right';
+export type TextAlignment = 'left' | 'center' | 'right';
+/**
  * Add additional css classes that should be applied to the section
  */
 export type AdditionalClass = string;
@@ -62,18 +63,20 @@ export type KsComponentAttribute = string;
 
 export interface SectionProps {
   width?: Width;
-  headlineWidth?: HeadlineWidth;
-  headlineAlign?: HeadlineAlignment;
-  contentWidth?: ContentWidth;
-  contentAlign?: ContentAlignment;
-  gutter?: Gutter;
-  mode?: Mode;
+  content?: {
+    width?: ContentWidth;
+    align?: ContentAlignment;
+    gutter?: Gutter;
+    mode?: Mode;
+  };
   background?: Background;
   inverted?: Inverted;
   spaceBefore?: SpaceBefore;
   spaceAfter?: SpaceAfter;
   headline?: {
-    align?: string;
+    width?: HeadlineBoxWidth;
+    align?: HeadlineBoxAlignment;
+    textAlign?: TextAlignment;
   } & HeadlineProps;
   className?: AdditionalClass;
   component?: KsComponentAttribute;

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -41,6 +41,11 @@
           "description": "Layout mode used for section contents",
           "enum": ["default", "tile", "list"],
           "default": "default"
+        },
+        "className": {
+          "type": "string",
+          "title": "Additional Content Class",
+          "description": "Additional css classes that should be applied to the content section container"
         }
       }
     },
@@ -94,6 +99,11 @@
               "title": "Text Alignment",
               "type": "string",
               "enum": ["left", "center", "right"]
+            },
+            "className": {
+              "type": "string",
+              "title": "Additional Headline Class",
+              "description": "Additional css classes that should be applied to the headline section container"
             }
           }
         },

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -11,46 +11,38 @@
       "enum": ["narrow", "default", "wide", "max", "full"],
       "default": "default"
     },
-    "headlineWidth": {
-      "type": "string",
-      "title": "Headline Width",
-      "description": "Width of headline to use",
-      "enum": ["unset", "narrow", "default", "wide"],
-      "default": "unset"
-    },
-    "headlineAlign": {
-      "title": "Headline Alignment",
-      "description": "Choose an alignment for the headline",
-      "type": "string",
-      "enum": ["left", "center", "right"]
-    },
-    "contentWidth": {
-      "type": "string",
-      "title": "Content Width",
-      "description": "Width of content to use",
-      "enum": ["unset", "narrow", "default", "wide"],
-      "default": "unset"
-    },
-    "contentAlign": {
-      "title": "Content Alignment",
-      "description": "Choose an alignment for the content",
-      "type": "string",
-      "enum": ["left", "center", "right"],
-      "default": "center"
-    },
-    "gutter": {
-      "type": "string",
-      "title": "Gutter",
-      "description": "Size of gutter to use",
-      "enum": ["large", "default", "small", "none"],
-      "default": "default"
-    },
-    "mode": {
-      "type": "string",
-      "title": "Mode",
-      "description": "Layout mode used for section contents",
-      "enum": ["default", "tile", "list"],
-      "default": "default"
+    "content": {
+      "type": "object",
+      "properties": {
+        "width": {
+          "type": "string",
+          "title": "Content Width",
+          "description": "Width of content to use",
+          "enum": ["unset", "narrow", "default", "wide"],
+          "default": "unset"
+        },
+        "align": {
+          "title": "Content Alignment",
+          "description": "Choose an alignment for the content",
+          "type": "string",
+          "enum": ["left", "center", "right"],
+          "default": "center"
+        },
+        "gutter": {
+          "type": "string",
+          "title": "Gutter",
+          "description": "Size of gutter to use",
+          "enum": ["large", "default", "small", "none"],
+          "default": "default"
+        },
+        "mode": {
+          "type": "string",
+          "title": "Mode",
+          "description": "Layout mode used for section contents",
+          "enum": ["default", "tile", "list"],
+          "default": "default"
+        }
+      }
     },
     "background": {
       "type": "string",
@@ -84,9 +76,24 @@
         {
           "type": "object",
           "properties": {
-            "align": {
+            "width": {
               "type": "string",
+              "title": "Headline Box Width",
+              "description": "Width of headline to use",
+              "enum": ["unset", "narrow", "default", "wide"],
+              "default": "unset"
+            },
+            "align": {
+              "title": "Headline Box Alignment",
+              "description": "Choose an alignment for the headline",
+              "type": "string",
+              "enum": ["left", "center", "right"],
               "default": null
+            },
+            "textAlign": {
+              "title": "Text Alignment",
+              "type": "string",
+              "enum": ["left", "center", "right"]
             }
           }
         },

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -31,21 +31,6 @@ $vars: meta.module-variables(section-vars);
     padding-bottom: 0;
   }
 
-  &__content {
-    margin: auto;
-    padding: 0 var(--l-section--content-padding);
-    max-width: var(--l-section--content-width-default);
-
-    &--max {
-      max-width: var(--l-section--content-width-max);
-    }
-
-    &--full {
-      max-width: var(--l-section--content-width-full);
-      padding: 0;
-    }
-  }
-
   &__container {
     margin: auto;
     display: grid;
@@ -57,6 +42,7 @@ $vars: meta.module-variables(section-vars);
       )
     );
     grid-gap: var(--l-section--gutter);
+    padding: 0 var(--l-section--content-padding);
 
     &--default {
       max-width: var(--l-section--content-width-default);
@@ -80,6 +66,23 @@ $vars: meta.module-variables(section-vars);
     }
     &--wide {
       max-width: var(--l-section--content-width-wide);
+    }
+  }
+
+  &__content {
+    margin: auto;
+    max-width: var(--l-section--content-width-default);
+
+    &--max {
+      max-width: var(--l-section--content-width-max);
+    }
+
+    &--full {
+      max-width: var(--l-section--content-width-full);
+
+      .l-section__container {
+        padding: 0;
+      }
     }
   }
 }

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -31,6 +31,22 @@ $vars: meta.module-variables(section-vars);
     padding-bottom: 0;
   }
 
+  &__content {
+    margin: auto;
+    padding: 0 var(--l-section--content-padding);
+    max-width: var(--l-section--content-width-default);
+    box-sizing: content-box;
+
+    &--max {
+      max-width: var(--l-section--content-width-max);
+    }
+
+    &--full {
+      max-width: var(--l-section--content-width-full);
+      padding: 0;
+    }
+  }
+
   &__container {
     margin: auto;
     display: grid;
@@ -42,7 +58,7 @@ $vars: meta.module-variables(section-vars);
       )
     );
     grid-gap: var(--l-section--gutter);
-    padding: 0 var(--l-section--content-padding);
+    box-sizing: border-box;
 
     &--default {
       max-width: var(--l-section--content-width-default);
@@ -59,30 +75,11 @@ $vars: meta.module-variables(section-vars);
 
   &__content,
   &__container {
-    width: 100%;
-
     &--narrow {
       max-width: var(--l-section--content-width-narrow);
     }
     &--wide {
       max-width: var(--l-section--content-width-wide);
-    }
-  }
-
-  &__content {
-    margin: auto;
-    max-width: var(--l-section--content-width-default);
-
-    &--max {
-      max-width: var(--l-section--content-width-max);
-    }
-
-    &--full {
-      max-width: var(--l-section--content-width-full);
-
-      .l-section__container {
-        padding: 0;
-      }
     }
   }
 }

--- a/packages/tools/bundler/bundle/scss.ts
+++ b/packages/tools/bundler/bundle/scss.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { pathToFileURL } from 'url';
-import sass from 'sass';
+import * as sass from 'sass';
 import chokidar from 'chokidar';
 import postcss from 'postcss';
 import postcssPlugins from './postcssPlugins.js';


### PR DESCRIPTION
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@3.0.0-canary.1523.6422.0
  npm install @kickstartds/blog@3.0.0-canary.1523.6422.0
  npm install @kickstartds/core@3.0.0-canary.1523.6422.0
  npm install @kickstartds/form@3.0.0-canary.1523.6422.0
  npm install @kickstartds/bundler@3.0.0-canary.1523.6422.0
  # or 
  yarn add @kickstartds/base@3.0.0-canary.1523.6422.0
  yarn add @kickstartds/blog@3.0.0-canary.1523.6422.0
  yarn add @kickstartds/core@3.0.0-canary.1523.6422.0
  yarn add @kickstartds/form@3.0.0-canary.1523.6422.0
  yarn add @kickstartds/bundler@3.0.0-canary.1523.6422.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

## Breaking Changes

* Prop `headline.align` is moved to `headline.textAlign`
* Prop `headlineWidth` is moved to `headline.width`
* Prop `headlineAlign` is moved to `headline.align`
* Prop `contentWidth` is moved to `content.width`
* Prop `contentAlign` is moved to `content.align`
* Prop `gutter` is moved to `content.gutter`
* Prop `mode` is moved to `content.mode`