### PR TITLE
Add button group to section

### DIFF
--- a/packages/components/base/source/button-group/ButtonGroupComponent.tsx
+++ b/packages/components/base/source/button-group/ButtonGroupComponent.tsx
@@ -8,11 +8,14 @@ export { ButtonGroupProps };
 export const ButtonGroupComponent: ForwardRefRenderFunction<
   HTMLDivElement,
   ButtonGroupProps & HTMLAttributes<HTMLDivElement>
-> = ({ items = [], align = 'left', className, component, ...props }, ref) => (
+> = (
+  { items = [], arrangement = 'left', className, component, ...props },
+  ref
+) => (
   <div
     className={classnames(
       'c-button-group',
-      `c-button-group--${align}`,
+      `c-button-group--${arrangement}`,
       className
     )}
     ks-component={component}

--- a/packages/components/base/source/button-group/ButtonGroupProps.ts
+++ b/packages/components/base/source/button-group/ButtonGroupProps.ts
@@ -12,9 +12,9 @@ import type { ButtonProps } from '@kickstartds/base/lib/button/typing';
  */
 export type Buttons = ButtonProps[];
 /**
- * Vertical alignment of the buttons
+ * Vertical arrangement of the buttons
  */
-export type VerticalAlignment =
+export type ButtonArrangement =
   | 'left'
   | 'center'
   | 'right'
@@ -34,7 +34,7 @@ export type KsComponentAttribute = string;
  */
 export interface ButtonGroupProps {
   items?: Buttons;
-  align?: VerticalAlignment;
+  arrangement?: ButtonArrangement;
   className?: AdditionalClasses;
   component?: KsComponentAttribute;
 }

--- a/packages/components/base/source/button-group/button-group.schema.json
+++ b/packages/components/base/source/button-group/button-group.schema.json
@@ -13,9 +13,9 @@
         "$ref": "http://schema.kickstartds.com/base/button.schema.json"
       }
     },
-    "align": {
-      "title": "Vertical Alignment",
-      "description": "Vertical alignment of the buttons",
+    "arrangement": {
+      "title": "Button arrangement",
+      "description": "Vertical arrangement of the buttons",
       "type": "string",
       "enum": ["left", "center", "right", "space-between", "grow"],
       "default": "left"

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -1,6 +1,7 @@
 import { ForwardRefRenderFunction, HTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { Headline } from '../headline';
+import { ButtonGroup } from '../button-group';
 import type { SectionProps } from './typing';
 
 const containerClassName = (
@@ -41,6 +42,7 @@ export const SectionComponent: ForwardRefRenderFunction<
     width = 'default',
     content = {} as SectionProps['content'],
     headline = {} as SectionProps['headline'],
+    buttons = {} as SectionProps['buttons'],
     className,
     component,
     children,
@@ -62,6 +64,8 @@ export const SectionComponent: ForwardRefRenderFunction<
     className: headlineClassName,
     ...headlineProps
   } = headline;
+  const { align: buttonsAlign = contentAlign, className: buttonsClassName } =
+    buttons;
   return (
     <div
       className={classnames(
@@ -82,7 +86,7 @@ export const SectionComponent: ForwardRefRenderFunction<
     >
       <div
         className={containerClassName(
-          { width: width !== 'default' ? width : undefined },
+          { width: width !== 'default' ? width : undefined, gutter },
           'l-section__content'
         )}
       >
@@ -99,8 +103,8 @@ export const SectionComponent: ForwardRefRenderFunction<
             )}
           >
             <Headline
-              align={headlineTextAlign || headlineAlign}
               {...headlineProps}
+              align={headlineTextAlign || headlineAlign}
             />
           </div>
         )}
@@ -110,7 +114,6 @@ export const SectionComponent: ForwardRefRenderFunction<
               {
                 width: contentWidth !== 'unset' ? contentWidth : undefined,
                 align: contentAlign,
-                gutter,
                 mode,
               },
               'l-section__container',
@@ -119,6 +122,21 @@ export const SectionComponent: ForwardRefRenderFunction<
             )}
           >
             {children}
+          </div>
+        )}
+        {buttons.items && buttons.items.length > 0 && (
+          <div
+            className={containerClassName(
+              {
+                width: contentWidth !== 'unset' ? contentWidth : undefined,
+                align: contentAlign,
+              },
+              'l-section__container',
+              'l-section__container--buttons',
+              buttonsClassName
+            )}
+          >
+            <ButtonGroup {...buttons} align={buttonsAlign} />
           </div>
         )}
       </div>

--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -64,8 +64,10 @@ export const SectionComponent: ForwardRefRenderFunction<
     className: headlineClassName,
     ...headlineProps
   } = headline;
-  const { align: buttonsAlign = contentAlign, className: buttonsClassName } =
-    buttons;
+  const {
+    arrangement: buttonsArrangement = contentAlign,
+    className: buttonsClassName,
+  } = buttons;
   return (
     <div
       className={classnames(
@@ -136,7 +138,7 @@ export const SectionComponent: ForwardRefRenderFunction<
               buttonsClassName
             )}
           >
-            <ButtonGroup {...buttons} align={buttonsAlign} />
+            <ButtonGroup {...buttons} arrangement={buttonsArrangement} />
           </div>
         )}
       </div>

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -94,7 +94,7 @@ export interface SectionProps {
     className?: AdditionalHeadlineClass;
   } & HeadlineProps;
   buttons?: {
-    align?: string;
+    arrangement?: string;
     className?: AdditionalButtonsClass;
   } & ButtonGroupProps;
   className?: AdditionalClass;

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -6,6 +6,7 @@
  */
 
 import type { HeadlineProps } from '@kickstartds/base/lib/headline/typing';
+import type { ButtonGroupProps } from '@kickstartds/base/lib/button-group/typing';
 
 /**
  * Width of section to use
@@ -61,6 +62,10 @@ export type TextAlignment = 'left' | 'center' | 'right';
  */
 export type AdditionalHeadlineClass = string;
 /**
+ * Additional css classes that should be applied to the buttons section container
+ */
+export type AdditionalButtonsClass = string;
+/**
  * Add additional css classes that should be applied to the section
  */
 export type AdditionalClass = string;
@@ -88,6 +93,10 @@ export interface SectionProps {
     textAlign?: TextAlignment;
     className?: AdditionalHeadlineClass;
   } & HeadlineProps;
+  buttons?: {
+    align?: string;
+    className?: AdditionalButtonsClass;
+  } & ButtonGroupProps;
   className?: AdditionalClass;
   component?: KsComponentAttribute;
 }

--- a/packages/components/base/source/section/_section-vars.scss
+++ b/packages/components/base/source/section/_section-vars.scss
@@ -26,16 +26,16 @@ $host: (
   '.l-section--bold': (
     background: var(--l-section--background-bold),
   ),
-  '.l-section__container': (
+  '.l-section__content': (
     gutter: var(--l-section--gutter-default),
   ),
-  '.l-section__container--gutter-none': (
+  '.l-section__content--gutter-none': (
     gutter: 0,
   ),
-  '.l-section__container--gutter-small': (
+  '.l-section__content--gutter-small': (
     gutter: var(--l-section--gutter-small),
   ),
-  '.l-section__container--gutter-large': (
+  '.l-section__content--gutter-large': (
     gutter: var(--l-section--gutter-large),
   ),
 ) !default;
@@ -51,5 +51,11 @@ $col: (
   ),
   '.l-section__container--list': (
     repeat: 1,
+  ),
+) !default;
+
+$buttons: (
+  '.l-section__content': (
+    space-before: var(--l-section--gutter),
   ),
 ) !default;

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -115,7 +115,7 @@
         {
           "type": "object",
           "properties": {
-            "align": {
+            "arrangement": {
               "type": "string",
               "default": null
             },

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -110,6 +110,27 @@
         { "$ref": "http://schema.kickstartds.com/base/headline.schema.json" }
       ]
     },
+    "buttons": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "align": {
+              "type": "string",
+              "default": null
+            },
+            "className": {
+              "type": "string",
+              "title": "Additional Buttons Class",
+              "description": "Additional css classes that should be applied to the buttons section container"
+            }
+          }
+        },
+        {
+          "$ref": "http://schema.kickstartds.com/base/button-group.schema.json"
+        }
+      ]
+    },
     "className": {
       "type": "string",
       "title": "Additional Class",

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -49,16 +49,23 @@ $vars: meta.module-variables(section-vars);
 
   &__container {
     margin: auto;
-    display: grid;
-    grid-template-columns: repeat(
-      var(--l-section_col--repeat),
-      minmax(
-        min(var(--l-section_col--min-width), 100%),
-        var(--l-section_col--max-width)
-      )
-    );
-    grid-gap: var(--l-section--gutter);
     box-sizing: border-box;
+
+    &--content {
+      display: grid;
+      grid-template-columns: repeat(
+        var(--l-section_col--repeat),
+        minmax(
+          min(var(--l-section_col--min-width), 100%),
+          var(--l-section_col--max-width)
+        )
+      );
+      grid-gap: var(--l-section--gutter);
+    }
+
+    &--buttons:not(:first-child) {
+      margin-top: var(--l-section_buttons--space-before);
+    }
 
     &--default {
       max-width: var(--l-section--content-width-default);


### PR DESCRIPTION
The Section component can now display one or more buttons below the content.

```jsx
<Section
  buttons={{
    arrangement: "center", // can be 'left', 'center', 'right', 'space-between', 'grow' or undefined
    items: [
      { label: "Button 1", href: "#" },
      { label: "Button 2", href: "#" },
    ],
  }}
>{...}</Section>
```

If `buttons.arrangement` is omitted, the alinment is inherited from `content.align` Prop.

This resolves #1524
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.3.0-canary.1527.6451.0
  npm install @kickstartds/blog@2.3.0-canary.1527.6451.0
  npm install @kickstartds/form@2.3.0-canary.1527.6451.0
  # or 
  yarn add @kickstartds/base@2.3.0-canary.1527.6451.0
  yarn add @kickstartds/blog@2.3.0-canary.1527.6451.0
  yarn add @kickstartds/form@2.3.0-canary.1527.6451.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
