### PR TITLE
Fix `Select Field` schema: `icon` property set to `object`, should be `string`

### DIFF
--- a/packages/components/form/source/form-field/select-field/SelectFieldProps.ts
+++ b/packages/components/form/source/form-field/select-field/SelectFieldProps.ts
@@ -65,7 +65,7 @@ export interface SelectFieldProps {
   invalid?: Invalid;
   invalidMessage?: InvalidMessage;
   hint?: HintMessage;
-  icon?: IconIdentifier;
+  icon?: IconIdentifier & string;
   className?: Class;
   component?: KsComponentAttribute;
 }

--- a/packages/components/form/source/form-field/select-field/select-field.schema.json
+++ b/packages/components/form/source/form-field/select-field/select-field.schema.json
@@ -50,7 +50,7 @@
       "$ref": "http://schema.kickstartds.com/form/input.definitions.json#/definitions/hint"
     },
     "icon": {
-      "type": "object",
+      "type": "string",
       "allOf": [
         {
           "type": "string",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/form@2.2.2-canary.1573.6569.0
  # or 
  yarn add @kickstartds/form@2.2.2-canary.1573.6569.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
