### PR TITLE
Add `tileWidth` Prop to section 

### DIFF
--- a/packages/components/base/source/section/SectionComponent.tsx
+++ b/packages/components/base/source/section/SectionComponent.tsx
@@ -78,8 +78,12 @@ export const SectionComponent: ForwardRefRenderFunction<
     align: contentAlign = 'center',
     gutter = 'default',
     mode = 'default',
-    className: contentClassName,
+    tileWidth = 'default',
   } = content;
+  const contentClassName = classnames(
+    content.className,
+    tileWidth !== 'default' && `l-section__content--tiles-${tileWidth}`
+  );
   const {
     width: headlineWidth = 'unset',
     align: headlineAlign = contentAlign,

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -29,6 +29,10 @@ export type Gutter = 'large' | 'default' | 'small' | 'none';
  */
 export type Mode = 'default' | 'tile' | 'list' | 'slider';
 /**
+ * Set min-width for the tiles in the grid
+ */
+export type TileWidth = 'smallest' | 'default' | 'medium' | 'large' | 'largest';
+/**
  * Additional css classes that should be applied to the content section container
  */
 export type AdditionalContentClass = string;
@@ -95,6 +99,7 @@ export interface SectionProps {
     align?: ContentAlignment;
     gutter?: Gutter;
     mode?: Mode;
+    tileWidth?: TileWidth;
     className?: AdditionalContentClass;
   };
   background?: Background;

--- a/packages/components/base/source/section/_section-vars.scss
+++ b/packages/components/base/source/section/_section-vars.scss
@@ -40,7 +40,7 @@ $host: (
 
 $col: (
   '.l-section__content': (
-    min-width: 18rem,
+    min-width: var(--l-section_tile-width--default),
     max-width: 1fr,
     repeat: 'auto-fit',
   ),
@@ -49,6 +49,16 @@ $col: (
   ),
   '.l-section__content--list': (
     repeat: 1,
+  ),
+) !default;
+
+$tile-width: (
+  '.l-section__content': (
+    smallest: 14rem,
+    default: 18rem,
+    medium: var(--l-section--content-width-narrow),
+    large: var(--l-section--content-width-default),
+    largest: var(--l-section--content-width-wide),
   ),
 ) !default;
 

--- a/packages/components/base/source/section/section.schema.json
+++ b/packages/components/base/source/section/section.schema.json
@@ -42,6 +42,13 @@
           "enum": ["default", "tile", "list", "slider"],
           "default": "default"
         },
+        "tileWidth": {
+          "type": "string",
+          "title": "Tile Width",
+          "description": "Set min-width for the tiles in the grid",
+          "enum": ["smallest", "default", "medium", "large", "largest"],
+          "default": "default"
+        },
         "className": {
           "type": "string",
           "title": "Additional Content Class",

--- a/packages/components/base/source/section/section.scss
+++ b/packages/components/base/source/section/section.scss
@@ -58,6 +58,12 @@ $vars: meta.module-variables(section-vars);
       }
     }
 
+    @each $tileWidth in ('smallest', 'medium', 'large', 'largest') {
+      &--tiles-#{$tileWidth} {
+        --l-section_col--min-width: var(--l-section_tile-width--#{$tileWidth});
+      }
+    }
+
     margin: auto;
     box-sizing: border-box;
     max-width: min(


### PR DESCRIPTION
New prop `tileWidth` modifies the width of components inside the section if `mode` is `default`, `tile` or `slider`.

Possible values:

* `smallest`: `14rem`
* `default` (default): `18rem`
* `medium`: `var(--l-section--content-width-narrow)`
* `large`: `var(--l-section--content-width-default)`
* `largest`: `var(--l-section--content-width-wide)`

Each value can be overwritten with the css custom property `--l-section_tile-width--[smallest|default|medium|large|largest]` on the `.l-section__content` element.

Resolves #1580

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.3.0-canary.1586.6599.0
  npm install @kickstartds/blog@2.3.0-canary.1586.6599.0
  npm install @kickstartds/form@2.3.0-canary.1586.6599.0
  # or 
  yarn add @kickstartds/base@2.3.0-canary.1586.6599.0
  yarn add @kickstartds/blog@2.3.0-canary.1586.6599.0
  yarn add @kickstartds/form@2.3.0-canary.1586.6599.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
