### PR TITLE
Add `color` & `file` to text-field's type prop

### DIFF
--- a/packages/components/form/source/form-field/text-field/TextFieldProps.ts
+++ b/packages/components/form/source/form-field/text-field/TextFieldProps.ts
@@ -29,9 +29,11 @@ export type Placeholder = string;
  * The type of input to render
  */
 export type Type =
+  | 'color'
   | 'date'
   | 'datetime-local'
   | 'email'
+  | 'file'
   | 'month'
   | 'number'
   | 'password'

--- a/packages/components/form/source/form-field/text-field/text-field.schema.json
+++ b/packages/components/form/source/form-field/text-field/text-field.schema.json
@@ -25,9 +25,11 @@
       "description": "The type of input to render",
       "type": "string",
       "enum": [
+        "color",
         "date",
         "datetime-local",
         "email",
+        "file",
         "month",
         "number",
         "password",


### PR DESCRIPTION
Resolves #1545

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/form@4.0.3-canary.1642.6845.0
  # or 
  yarn add @kickstartds/form@4.0.3-canary.1642.6845.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
