### PR TITLE
Add `open` prop to collapsible box

### DIFF
--- a/packages/components/base/source/collapsible-box/CollapsibleBoxComponent.tsx
+++ b/packages/components/base/source/collapsible-box/CollapsibleBoxComponent.tsx
@@ -22,6 +22,7 @@ export const CollapsibleBoxComponent: ForwardRefRenderFunction<
     renderSummary = defaultRenderFn,
     text,
     renderText = richTextDefaultRenderFn,
+    open,
     children,
     className,
     component = 'base.collapsible-box',
@@ -35,7 +36,7 @@ export const CollapsibleBoxComponent: ForwardRefRenderFunction<
     ref={ref}
     {...props}
   >
-    <details>
+    <details open={open}>
       <summary className="c-collapsible-box__header">
         <div className="c-collapsible-box__header-wrapper">
           <span className="c-collapsible-box__header__text">

--- a/packages/components/base/source/collapsible-box/CollapsibleBoxProps.ts
+++ b/packages/components/base/source/collapsible-box/CollapsibleBoxProps.ts
@@ -13,6 +13,7 @@ export type SummaryTextForTheCollapsible = string;
  * Include the text for the collapsible that should be visible after opening
  */
 export type ContentOfTheCollapsible = string;
+export type InitialOpen = boolean;
 /**
  * Additional css classes attached to the wrapping element
  */
@@ -28,6 +29,7 @@ export type KsComponentAttribute = string;
 export interface CollapsibleBoxProps {
   summary: SummaryTextForTheCollapsible;
   text: ContentOfTheCollapsible;
+  open?: InitialOpen;
   className?: Class;
   component?: KsComponentAttribute;
 }

--- a/packages/components/base/source/collapsible-box/collapsible-box.schema.json
+++ b/packages/components/base/source/collapsible-box/collapsible-box.schema.json
@@ -20,6 +20,11 @@
         "Proin risus est, rhoncus ut neque iaculis, rhoncus semper felis. Phasellus vel erat interdum, blandit metus et, congue velit. Sed hendrerit sapien vitae tincidunt aliquam. Mauris ac dui sodales risus egestas vestibulum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed vitae lectus augue. Donec non magna ultricies, pulvinar quam vel, rutrum quam. Nulla quis suscipit libero. Fusce cursus vehicula lacus vel ullamcorper. Ut ullamcorper tempus elit. Morbi vel eleifend nunc, vitae rutrum nunc."
       ]
     },
+    "open": {
+      "title": "Initial open",
+      "type": "boolean",
+      "default": false
+    },
     "className": {
       "title": "Class",
       "description": "Additional css classes attached to the wrapping element",

--- a/packages/components/base/source/section/SectionProps.ts
+++ b/packages/components/base/source/section/SectionProps.ts
@@ -209,6 +209,7 @@ export type SummaryTextForTheCollapsible = string;
  * Include the text for the collapsible that should be visible after opening
  */
 export type ContentOfTheCollapsible = string;
+export type InitialOpen = boolean;
 /**
  * Additional css classes attached to the wrapping element
  */
@@ -873,6 +874,7 @@ export interface Picture {
 export interface CollapsibleBox {
   summary: SummaryTextForTheCollapsible;
   text: ContentOfTheCollapsible;
+  open?: InitialOpen;
   className?: Class1;
   component?: KsComponentAttribute6;
 }


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@2.3.0-canary.1646.6875.0
  npm install @kickstartds/blog@2.3.0-canary.1646.6875.0
  npm install @kickstartds/form@2.3.0-canary.1646.6875.0
  # or 
  yarn add @kickstartds/base@2.3.0-canary.1646.6875.0
  yarn add @kickstartds/blog@2.3.0-canary.1646.6875.0
  yarn add @kickstartds/form@2.3.0-canary.1646.6875.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
