### PR TITLE
Fix inverted translucent background color

### DIFF
--- a/packages/tools/style-dictionary/templates/background-color/custom.js
+++ b/packages/tools/style-dictionary/templates/background-color/custom.js
@@ -28,7 +28,7 @@ module.exports = (key) => {
         active: { base: token(`{ks.color.${key}-inverted.to-bg.2.base}`) },
         selected: { base: token(`{ks.color.${key}-inverted.to-bg.4.base}`) },
       },
-      translucent: { base: token(`{ks.color.${key}-inverted.alpha.5.base}`) },
+      translucent: { base: token(`{ks.color.${key}-inverted.alpha.2.base}`) },
     },
   };
 };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @kickstartds/base@4.0.5-canary.1651.6934.0
  npm install @kickstartds/blog@4.0.5-canary.1651.6934.0
  npm install @kickstartds/core@4.0.5-canary.1651.6934.0
  npm install @kickstartds/form@4.0.5-canary.1651.6934.0
  npm install @kickstartds/style-dictionary@4.0.4-canary.1651.6934.0
  # or 
  yarn add @kickstartds/base@4.0.5-canary.1651.6934.0
  yarn add @kickstartds/blog@4.0.5-canary.1651.6934.0
  yarn add @kickstartds/core@4.0.5-canary.1651.6934.0
  yarn add @kickstartds/form@4.0.5-canary.1651.6934.0
  yarn add @kickstartds/style-dictionary@4.0.4-canary.1651.6934.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
