### PR TITLE
add missing component token #993

### DIFF
--- a/packages/components/base/source/collapsible-box/_collapsible-box-vars.scss
+++ b/packages/components/base/source/collapsible-box/_collapsible-box-vars.scss
@@ -9,6 +9,7 @@ $host: (
 $header: (
   '.c-collapsible-box': (
     font: var(--ks-font-copy-m),
+    color: var(--ks-text-color-default),
     padding: (
       0: 1em 0,
       640: 1em,

--- a/packages/components/base/source/collapsible-box/collapsible-box.scss
+++ b/packages/components/base/source/collapsible-box/collapsible-box.scss
@@ -22,6 +22,8 @@ $vars: meta.module-variables(collapsible-box-vars);
   border-bottom: 1px solid var(--c-collapsible-box--border-color);
 
   &__header {
+    color: var(--c-collapsible-box_header--color);
+
     &-wrapper {
       position: relative;
       padding: var(--c-collapsible-box_header--padding);

--- a/packages/components/base/source/content-box/_content-box-vars.scss
+++ b/packages/components/base/source/content-box/_content-box-vars.scss
@@ -1,5 +1,11 @@
 $name-: 'c-content-box' !default;
 
+$host: (
+  '.c-content-box': (
+    margin-bottom: null,
+  ),
+) !default;
+
 $topic: (
   '.c-content-box': (
     font-xs: var(--ks-font-display-s),
@@ -9,5 +15,16 @@ $topic: (
     font-weight: var(--c-rich-text_headline--font-weight),
     color: var(--c-rich-text_headline--color),
     margin: null,
+  ),
+) !default;
+
+$image: (
+  '.c-content-box': (
+    margin-bottom: 1em,
+  ),
+) !default;
+$link: (
+  '.c-content-box': (
+    margin-top: 1em,
   ),
 ) !default;

--- a/packages/components/base/source/content-box/content-box.scss
+++ b/packages/components/base/source/content-box/content-box.scss
@@ -11,7 +11,7 @@ $vars: meta.module-variables(content-box-vars);
 }
 
 .c-content-box {
-  margin-bottom: 2em;
+  margin-bottom: var(--c-content-box--margin-bottom);
   box-sizing: border-box;
   contain: layout inline-size style;
   display: flex;
@@ -30,7 +30,7 @@ $vars: meta.module-variables(content-box-vars);
     flex-grow: 0;
     flex-shrink: 0;
     width: 100%;
-    margin-bottom: 1em;
+    margin-bottom: var(--c-content-box_image--margin-bottom);
 
     img {
       width: auto;
@@ -84,6 +84,6 @@ $vars: meta.module-variables(content-box-vars);
   }
 
   &__link {
-    margin-top: 1em;
+    margin-top: var(--c-content-box_link--margin-top);
   }
 }

--- a/packages/components/form/source/form-field/_form-field-vars.scss
+++ b/packages/components/form/source/form-field/_form-field-vars.scss
@@ -12,6 +12,13 @@ $host: (
   ),
 ) !default;
 
+$label: (
+  ':root, [ks-theme], [ks-inverted]': (
+    color: var(--ks-text-color-interface),
+    padding: 0.25rem 0,
+  ),
+) !default;
+
 $hover: (
   ':root, [ks-theme], [ks-inverted]': (
     border-color: var(--ks-border-color-interface-interactive-hover),

--- a/packages/components/form/source/form-field/form-field.scss
+++ b/packages/components/form/source/form-field/form-field.scss
@@ -14,7 +14,8 @@ $vars: meta.module-variables(form-field-vars);
   flex-direction: column;
 
   &__label {
-    padding: 0.25rem 0;
+    color: var(--c-form-field_label--color);
+    padding: var(--c-form-field_label--padding);
 
     &--hidden {
       @include bourbon.hide-visually;


### PR DESCRIPTION
Some component tokens were added to replace previously directly applied CSS in the component.
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `@kickstartds/base@4.1.1-next.0`
`@kickstartds/blog@4.1.1-next.0`
`@kickstartds/form@4.1.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - `@kickstartds/base`, `@kickstartds/form`
    - add missing component token #993 [#1706](https://github.com/kickstartDS/kickstartDS/pull/1706) ([@fleven-kds](https://github.com/fleven-kds))
  
  #### Authors: 1
  
  - Franz ([@fleven-kds](https://github.com/fleven-kds))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
